### PR TITLE
周波数設定ができないバグ対応で部分的にシステムの内部挙動に合わせて変数名をMhzからHzに修正

### DIFF
--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -95,7 +95,7 @@ export class AppConfigSatellite {
  */
 export class Uplink {
   // アップリンク周波数(Mhz)
-  public uplinkMhz: number | null = null;
+  public uplinkHz: number | null = null;
   // アップリンクモード
   public uplinkMode = "";
 }
@@ -105,7 +105,7 @@ export class Uplink {
  */
 export class Downlink {
   // ダウンリンク周波数(Mhz)
-  public downlinkMhz: number | null = null;
+  public downlinkHz: number | null = null;
   // ダウンリンクモード
   public downlinkMode = "";
 }

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -213,7 +213,7 @@ const form = ref<EditSatelliteInfoForm>(new EditSatelliteInfoForm());
 const { validateForm, errors } = useEditSatelliteInfoValidate();
 
 // ファイルから取得した値と画面フォームで構造を変換する関数
-const { transformToForm, transformToAppConfig } = useEditSatelliteInfo();
+const { transformAppConfigToForm, transformDefSatToForm, transformFormToAppConfig } = useEditSatelliteInfo();
 
 onMounted(async function () {
   // 衛星を取得
@@ -224,7 +224,7 @@ onMounted(async function () {
   const appConfigSatellite = await ApiAppConfigSatellite.getAppConfigSatellite(selectedItem.value.satelliteId);
 
   // 画面に設定する
-  transformToForm(form.value, registedSatellite);
+  transformAppConfigToForm(form.value, registedSatellite);
   form.value.refSatelliteName = selectedItem.value.satelliteName;
   manualEditFlg.value = false;
 
@@ -275,14 +275,14 @@ async function onOk() {
     // リセットを押していたら(マニュアル設定がOFF)削除する
     if (manualEditFlg.value) {
       const sat: AppConfigSatellite = appConfig.satellites[index];
-      transformToAppConfig(sat, form.value);
+      transformFormToAppConfig(sat, form.value);
     } else {
       appConfig.satellites.splice(index, 1);
     }
   } else {
     // アプリケーション設定になければ新規追加
     const sat: AppConfigSatellite = new AppConfigSatellite();
-    transformToAppConfig(sat, form.value);
+    transformFormToAppConfig(sat, form.value);
     appConfig.satellites.push(sat);
   }
 
@@ -314,7 +314,7 @@ async function onReset() {
     selectedItem.value.satelliteId
   );
   if (defsat) {
-    transformToForm(form.value, defsat);
+    transformDefSatToForm(form.value, defsat);
   }
   manualEditFlg.value = false;
   isWatched = false;

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfo.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfo.ts
@@ -1,55 +1,75 @@
 import { AppConfigSatellite } from "@/common/model/AppConfigModel";
+import { DefaultSatelliteType } from "@/common/types/satelliteSettingTypes";
 import EditSatelliteInfoForm from "@/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfoForm";
 /**
  * 衛星情報編集画面関係のフック
  */
 export default function useEditSatelliteInfo() {
   /**
-   * 画面フォームの構造に変換する
+   * 画面フォームの構造に変換する(共通部分)
    * @param targetForm
    * @param srcObj
    */
-  function transformToForm(targetForm: EditSatelliteInfoForm, srcObj: any) {
+  function transformToForm(targetForm: EditSatelliteInfoForm, srcObj: AppConfigSatellite | DefaultSatelliteType) {
+    // 共通
     targetForm.satelliteId = srcObj.satelliteId;
     // 参照用はここでは設定しない
-    // デフォルト衛星の場合はsatelliteName
-    targetForm.editSatelliteName = srcObj.userRegisteredSatelliteName ?? srcObj.satelliteName;
     targetForm.noradId = srcObj.noradId;
-    targetForm.autoModeUplinkFreq = (srcObj.autoModeUplinkFreq ?? 1).toString();
-    targetForm.uplink1Mhz = srcObj.uplink1.uplinkMhz;
+    targetForm.uplink1Mhz = srcObj.uplink1.uplinkHz;
     targetForm.uplink1Mode = srcObj.uplink1.uplinkMode;
-    targetForm.uplink2Mhz = srcObj.uplink2.uplinkMhz;
+    targetForm.uplink2Mhz = srcObj.uplink2.uplinkHz;
     targetForm.uplink2Mode = srcObj.uplink2.uplinkMode;
-    targetForm.autoModeDownlinkFreq = (srcObj.autoModeDownlinkFreq ?? 1).toString();
-    targetForm.downlink1Mhz = srcObj.downlink1.downlinkMhz;
+    targetForm.downlink1Mhz = srcObj.downlink1.downlinkHz;
     targetForm.downlink1Mode = srcObj.downlink1.downlinkMode;
-    targetForm.downlink2Mhz = srcObj.downlink2.downlinkMhz;
+    targetForm.downlink2Mhz = srcObj.downlink2.downlinkHz;
     targetForm.downlink2Mode = srcObj.downlink2.downlinkMode;
     targetForm.toneMhz = srcObj.toneMhz;
     targetForm.outline = srcObj.outline;
+  }
+  /**
+   * 画面フォームの構造に変換する(アプリケーション設定用)
+   * @param targetForm
+   * @param srcObj
+   */
+  function transformAppConfigToForm(targetForm: EditSatelliteInfoForm, srcObj: AppConfigSatellite) {
+    transformToForm(targetForm, srcObj);
+    targetForm.editSatelliteName = srcObj.userRegisteredSatelliteName;
+    targetForm.autoModeUplinkFreq = (srcObj.autoModeUplinkFreq ?? 1).toString();
+    targetForm.autoModeDownlinkFreq = (srcObj.autoModeDownlinkFreq ?? 1).toString();
+  }
+  /**
+   * 画面フォームの構造に変換する(デフォルト衛星定義用)
+   * @param targetForm
+   * @param srcObj
+   */
+  function transformDefSatToForm(targetForm: EditSatelliteInfoForm, srcObj: DefaultSatelliteType) {
+    transformToForm(targetForm, srcObj);
+    targetForm.editSatelliteName = srcObj.satelliteName;
+    targetForm.autoModeUplinkFreq = "1";
+    targetForm.autoModeDownlinkFreq = "1";
   }
   /**
    * アプリケーション設定の構造に変換する
    * @param targetAppConfig
    * @param srcForm
    */
-  function transformToAppConfig(targetAppConfig: AppConfigSatellite, srcForm: EditSatelliteInfoForm) {
+  function transformFormToAppConfig(targetAppConfig: AppConfigSatellite, srcForm: EditSatelliteInfoForm) {
     targetAppConfig.satelliteId = srcForm.satelliteId;
     targetAppConfig.userRegisteredSatelliteName = srcForm.editSatelliteName;
     targetAppConfig.noradId = srcForm.noradId;
     targetAppConfig.autoModeUplinkFreq = parseInt(srcForm.autoModeUplinkFreq);
-    targetAppConfig.uplink1.uplinkMhz = srcForm.uplink1Mhz ? srcForm.uplink1Mhz : null;
+    targetAppConfig.uplink1.uplinkHz = srcForm.uplink1Mhz ? srcForm.uplink1Mhz : null;
     targetAppConfig.uplink1.uplinkMode = srcForm.uplink1Mode;
-    targetAppConfig.uplink2.uplinkMhz = srcForm.uplink2Mhz ? srcForm.uplink2Mhz : null;
+    targetAppConfig.uplink2.uplinkHz = srcForm.uplink2Mhz ? srcForm.uplink2Mhz : null;
     targetAppConfig.uplink2.uplinkMode = srcForm.uplink2Mode;
     targetAppConfig.autoModeDownlinkFreq = parseInt(srcForm.autoModeDownlinkFreq);
-    targetAppConfig.downlink1.downlinkMhz = srcForm.downlink1Mhz ? srcForm.downlink1Mhz : null;
+    targetAppConfig.downlink1.downlinkHz = srcForm.downlink1Mhz ? srcForm.downlink1Mhz : null;
     targetAppConfig.downlink1.downlinkMode = srcForm.downlink1Mode;
-    targetAppConfig.downlink2.downlinkMhz = srcForm.downlink2Mhz ? srcForm.downlink2Mhz : null;
+    targetAppConfig.downlink2.downlinkHz = srcForm.downlink2Mhz ? srcForm.downlink2Mhz : null;
     targetAppConfig.downlink2.downlinkMode = srcForm.downlink2Mode;
     targetAppConfig.toneMhz = srcForm.toneMhz ? srcForm.toneMhz : null;
     targetAppConfig.outline = srcForm.outline;
   }
 
-  return { transformToForm, transformToAppConfig };
+  return { transformAppConfigToForm, transformDefSatToForm, transformFormToAppConfig };
 }

--- a/src/renderer/service/ActiveSatServiceHub.ts
+++ b/src/renderer/service/ActiveSatServiceHub.ts
@@ -219,17 +219,19 @@ export default class ActiveSatServiceHub {
     if (appConfigSatellite) {
       if (appConfigSatellite.autoModeUplinkFreq === 2) {
         // アップリンク設定が2の場合は、設定2を使用する
+        // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
         this.uplinkFreq = {
-          uplinkHz: appConfigSatellite.uplink2.uplinkMhz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink2.uplinkMhz)
+          uplinkHz: appConfigSatellite.uplink2.uplinkHz
+            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink2.uplinkHz)
             : null,
           uplinkMode: appConfigSatellite.uplink2.uplinkMode,
         };
       } else {
         // それ以外は設定1を使用する
         this.uplinkFreq = {
-          uplinkHz: appConfigSatellite.uplink1.uplinkMhz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink1.uplinkMhz)
+          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
+          uplinkHz: appConfigSatellite.uplink1.uplinkHz
+            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink1.uplinkHz)
             : null,
           uplinkMode: appConfigSatellite.uplink1.uplinkMode,
         };
@@ -237,16 +239,18 @@ export default class ActiveSatServiceHub {
       if (appConfigSatellite.autoModeDownlinkFreq === 2) {
         // ダウンリンク設定が2の場合は、設定2を使用する
         this.downlinkFreq = {
-          downlinkHz: appConfigSatellite.downlink2.downlinkMhz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink2.downlinkMhz)
+          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
+          downlinkHz: appConfigSatellite.downlink2.downlinkHz
+            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink2.downlinkHz)
             : null,
           downlinkMode: appConfigSatellite.downlink2.downlinkMode,
         };
       } else {
         // それ以外は設定1を使用する
         this.downlinkFreq = {
-          downlinkHz: appConfigSatellite.downlink1.downlinkMhz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink1.downlinkMhz)
+          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
+          downlinkHz: appConfigSatellite.downlink1.downlinkHz
+            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink1.downlinkHz)
             : null,
           downlinkMode: appConfigSatellite.downlink1.downlinkMode,
         };


### PR DESCRIPTION
# 前提
- issues #7 にて周波数設定ができないと指摘があった
  - rendererからは周波数をxxxMhzという変数で取得するがmain側では一部xxxHzになっており値がundefinedになっていた
  - 周波数の入力欄に想定外の値(undefined)が入っていたことにより入力チェックがうまくできていなかった(ただし、0は入力チェックで正常に弾いた結果)
  - renderer側の関数の引数にanyを使っていたため、main側での変更が検知できなかった

# 実装概要
- main側の処置に合わせてrenderer側の一部の処理もxxxHzで取得するようにした
- すでにDefaultSatelliteTypeがHzになっているのでAppConfigModelもHzにした
- 処理ないでanyではなく型を指定するようにした

# 注意点
- もともとMhzで扱っていたためところどころMhzのままになっている
- ActiveSatServiceHubなどはMhztoHzの変換処理があり単純に置換するだけではダメそう
- 整合とりながらの修正が必要
- 
# 関連
issues #7 