### PR TITLE
ローテータの自動終了時間の対応

### DIFF
--- a/src/renderer/common/util/AutoTrackingHelper.ts
+++ b/src/renderer/common/util/AutoTrackingHelper.ts
@@ -1,0 +1,51 @@
+import { AppConfigModel } from "@/common/model/AppConfigModel";
+import ActiveSatServiceHub from "@/renderer/service/ActiveSatServiceHub";
+import DateUtil from "@/renderer/util/DateUtil";
+
+/**
+ * 自動追尾関係のヘルパ
+ */
+export default class AutoTrackingHelper {
+  /**
+   * ローテータの自動追尾の時間帯か判定する
+   * @param baseDate 基準時間
+   */
+  public static async isRotatorTrackingTimeRange(appConfig: AppConfigModel, baseDate: Date): Promise<boolean> {
+    // 現在の基準日時を元に、追尾開始・終了時間を加味した基準日時を取得する
+    const offsetDate = this.getOffsetBaseDate(appConfig, baseDate);
+
+    // パスを取得
+    const currentPass = await ActiveSatServiceHub.getInstance().getOrbitPassAsync(offsetDate);
+    if (!currentPass || !currentPass.aos || !currentPass.los) {
+      return false;
+    }
+
+    // ローテータ自動追尾の開始・終了時刻を取得
+    const addMinute = appConfig.rotator.startAgoMinute ?? 0;
+
+    // 自動追尾の開始時刻は「AOS - startAgoMinute」
+    const trackingStartDate = DateUtil.addMinute(currentPass.aos.date, addMinute * -1);
+    // 自動追尾の終了時刻は「LOS + startAgoMinute」
+    const trackingEndDate = DateUtil.addMinute(currentPass.los.date, addMinute);
+
+    // 自動追尾の時間範囲内
+    if (trackingStartDate.getTime() <= baseDate.getTime() && baseDate.getTime() <= trackingEndDate.getTime()) {
+      return true;
+    }
+
+    // 自動追尾の時間範囲外
+    return false;
+  }
+
+  /**
+   * 指定の基準日時を元に、追尾開始・終了時間を加味した基準日時を返す
+   */
+  public static getOffsetBaseDate(appConfig: AppConfigModel, baseDate: Date): Date {
+    // ローテータ自動追尾の開始・終了時刻を取得
+    const offsetMinute = appConfig.rotator.startAgoMinute ?? 0;
+    const offsetSec = offsetMinute * 60;
+
+    // 基準日時から追尾開始時間を引く
+    return DateUtil.addSec(baseDate, offsetSec * -1);
+  }
+}

--- a/src/renderer/common/util/AutoTrackingHelper.ts
+++ b/src/renderer/common/util/AutoTrackingHelper.ts
@@ -45,6 +45,8 @@ export default class AutoTrackingHelper {
     const offsetMinute = appConfig.rotator.startAgoMinute ?? 0;
     const offsetSec = offsetMinute * 60;
 
+    // todo: 無線機のAutoTrackingの開始・終了時刻の際は、ここでローテータのオフセットと比較して大きい方をオフセットとする
+
     // 基準日時から追尾開始時間を引く
     return DateUtil.addSec(baseDate, offsetSec * -1);
   }

--- a/src/renderer/common/util/AutoTrackingHelper.ts
+++ b/src/renderer/common/util/AutoTrackingHelper.ts
@@ -45,7 +45,7 @@ export default class AutoTrackingHelper {
     const offsetMinute = appConfig.rotator.startAgoMinute ?? 0;
     const offsetSec = offsetMinute * 60;
 
-    // todo: 無線機のAutoTrackingの開始・終了時刻の際は、ここでローテータのオフセットと比較して大きい方をオフセットとする
+    // todo: 無線機のAutoTrackingの開始・終了時刻の対応時は、ここでローテータのオフセットと比較して大きい方をオフセットとする
 
     // 基準日時から追尾開始時間を引く
     return DateUtil.addSec(baseDate, offsetSec * -1);

--- a/src/renderer/components/organisms/Radar/useDrawSatPass.ts
+++ b/src/renderer/components/organisms/Radar/useDrawSatPass.ts
@@ -1,4 +1,6 @@
 import Constant from "@/common/Constant";
+import ApiAppConfig from "@/renderer/api/ApiAppConfig";
+import AutoTrackingHelper from "@/renderer/common/util/AutoTrackingHelper";
 import GroundStationHelper from "@/renderer/common/util/GroundStationHelper";
 import ActiveSatServiceHub from "@/renderer/service/ActiveSatServiceHub";
 import { SatAzEl } from "@/renderer/types/satellite-type";
@@ -68,9 +70,15 @@ export default function useDrawSatPass(
       return;
     }
 
+    // 現在の基準日時を元に、追尾開始・終了時間を加味した基準日時を取得する
+    // memo: 素の基準日時を渡すと、LOS後に次のパスが取れてしまうため（余白的な追尾が出来ないため）
+    //       追尾開始・終了時間を加味した基準日時を元にパスを取得する
+    const appConfig = await ApiAppConfig.getAppConfig();
+    const baseDate = AutoTrackingHelper.getOffsetBaseDate(appConfig, currentDate.value);
+
     // 人工衛星のAOSリストを取得する
     const passes = await groundStationService.getOrbitPassListAsync(
-      currentDate.value,
+      baseDate,
       new Date(currentDate.value.getTime() + Constant.Time.MILLISECONDS_IN_DAY)
     );
     if (!passes || passes.length === 0) {

--- a/src/renderer/components/organisms/TransceiverCtrl/useOrbitalPassList.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useOrbitalPassList.ts
@@ -1,4 +1,6 @@
 import Constant from "@/common/Constant";
+import ApiAppConfig from "@/renderer/api/ApiAppConfig";
+import AutoTrackingHelper from "@/renderer/common/util/AutoTrackingHelper";
 import ActiveSatServiceHub from "@/renderer/service/ActiveSatServiceHub";
 import { PassesCache } from "@/renderer/types/pass-type";
 import { onMounted, onUnmounted, ref, watch, type Ref } from "vue";
@@ -30,9 +32,15 @@ const useOrbitalPassList = (currentDate: Ref<Date>) => {
       return;
     }
 
+    // 現在の基準日時を元に、追尾開始・終了時間を加味した基準日時を取得する
+    // memo: 素の基準日時を渡すと、LOS後に次のパスが取れてしまうため（余白的な追尾が出来ないため）
+    //       追尾開始・終了時間を加味した基準日時を元にパスを取得する
+    const appConfig = await ApiAppConfig.getAppConfig();
+    const baseDate = AutoTrackingHelper.getOffsetBaseDate(appConfig, currentDate.value);
+
     // 人工衛星のAOSリストを取得する
     orbitalPassList.value = await groundStationService.getOrbitPassListAsync(
-      currentDate.value,
+      baseDate,
       new Date(currentDate.value.getTime() + Constant.Time.MILLISECONDS_IN_DAY)
     );
   }

--- a/src/renderer/service/ActiveSatServiceHub.ts
+++ b/src/renderer/service/ActiveSatServiceHub.ts
@@ -4,6 +4,7 @@ import TransceiverUtil from "@/common/util/TransceiverUtil";
 import ApiActiveSat from "@/renderer/api/ApiActiveSat";
 import ApiAppConfig from "@/renderer/api/ApiAppConfig";
 import ApiAppConfigSatellite from "@/renderer/api/ApiAppConfigSatellite";
+import AutoTrackingHelper from "@/renderer/common/util/AutoTrackingHelper";
 import GroundStationServiceFactory from "@/renderer/common/util/GroundStationServiceFactory";
 import OrbitLineServiceFactory from "@/renderer/common/util/OrbitLineServiceFactory";
 import SatelliteServiceFactory from "@/renderer/common/util/SatelliteServiceFactory";
@@ -268,11 +269,17 @@ export default class ActiveSatServiceHub {
       return null;
     }
 
+    // 現在の基準日時を元に、追尾開始・終了時間を加味した基準日時を取得する
+    // memo: 素の基準日時を渡すと、LOS後に次のパスが取れてしまうため（余白的な追尾が出来ないため）
+    //       追尾開始・終了時間を加味した基準日時を元にパスを取得する
+    const appConfig = await ApiAppConfig.getAppConfig();
+    const baseDate = AutoTrackingHelper.getOffsetBaseDate(appConfig, date);
+
     // 2か所の地上局が有効な場合は、重複するAOS/LOSを取得する
     // （有効な場合：this.overlapPassesService != null）
     if (this.overlapPassesService) {
       const passes = await this.overlapPassesService.getOverlapPassesListAsync(
-        date,
+        baseDate,
         new Date(date.getTime() + Constant.Time.MILLISECONDS_IN_DAY)
       );
 
@@ -286,21 +293,8 @@ export default class ActiveSatServiceHub {
 
     // 地上局が１つの場合
     // 人工衛星の直近のAOS/LOSを返す
-    return await this.groundStationService.getOrbitPassAsync(date);
+    return await this.groundStationService.getOrbitPassAsync(baseDate);
   }
-
-  // public setBaseDate(date: Date) {
-  //   this.baseDate = date;
-
-  //   // コールバックを実行
-  //   this.baseDateChangeCallbacks.forEach((callback) => {
-  //     callback(this.baseDate);
-  //   });
-  // }
-
-  // public getBaseDate(): Date {
-  //   return this.baseDate;
-  // }
 
   /**
    * アクティブ衛星のSatelliteServiceのインスタンスを返す

--- a/src/renderer/util/DateUtil.ts
+++ b/src/renderer/util/DateUtil.ts
@@ -57,16 +57,22 @@ class DateUtil {
    * @returns {string} 単位付き日時文字列
    */
   public static formatMsToDHMS = (milliSeconds: number | null): string => {
-    if (!milliSeconds || milliSeconds < 0) {
-      // ミリ秒数値がnullまたはマイナス値の場合は"―"を返却する
+    if (!milliSeconds) {
+      // ミリ秒数値がnullの場合は"―"を返却する
       return I18nUtil.getMsg(I18nMsgs.GCOM_NA);
     }
 
+    // ミリ秒数値がマイナス値の場合は秒表現で返す（例：-3s）
+    if (milliSeconds < 0) {
+      const seconds = Math.floor(milliSeconds / 1000);
+      return `${seconds}s`;
+    }
+
     // ミリ秒数値をd h m s形式の文字列に変換する
-    const seconds = Math.floor((milliSeconds / 1000) % 60),
-      minutes = Math.floor((milliSeconds / (1000 * 60)) % 60),
-      hours = Math.floor((milliSeconds / (1000 * 60 * 60)) % 24),
-      days = Math.floor(milliSeconds / (1000 * 60 * 60 * 24));
+    const seconds = Math.floor((milliSeconds / 1000) % 60);
+    const minutes = Math.floor((milliSeconds / (1000 * 60)) % 60);
+    const hours = Math.floor((milliSeconds / (1000 * 60 * 60)) % 24);
+    const days = Math.floor(milliSeconds / (1000 * 60 * 60 * 24));
 
     if (days === 0 && hours === 0) {
       // d, hが0の場合はm s形式で表示する
@@ -86,6 +92,14 @@ class DateUtil {
   public static addMinute(date: Date, val: number): Date {
     const dt = dayjs(date);
     return dt.add(val, "minute").toDate();
+  }
+
+  /**
+   * 秒を加算（減算）する
+   */
+  public static addSec(date: Date, val: number): Date {
+    const dt = dayjs(date);
+    return dt.add(val, "second").toDate();
   }
 }
 


### PR DESCRIPTION
- LOS後に、ローテータ設定の自動追尾終了時間まで追尾を継続する
- 画面上部のAOS/LOS表示は、LOS後に自動追尾終了時間までマイナス秒を表示するようにした
- 画面右のAOS Listも自動追尾終了時間まで現在のパスを表示する