### PR TITLE
ローテータの現在位置のマイナス値を表示する

### DIFF
--- a/src/renderer/components/organisms/Radar/Radar.scss
+++ b/src/renderer/components/organisms/Radar/Radar.scss
@@ -80,9 +80,9 @@
 }
 .current_pos_item_az {
   position: absolute;
-  left: 10px;
+  left: 8px;
   top: 224px;
-  width: 95px;
+  width: 100px;
   height: 30px;
   padding: 6px 12px;
   border-radius: 4px;
@@ -96,7 +96,7 @@
   position: absolute;
   right: 50px;
   top: 224px;
-  width: 95px;
+  width: 100px;
   height: 30px;
   padding: 6px 12px;
   border-radius: 4px;

--- a/src/renderer/components/organisms/Radar/Radar.vue
+++ b/src/renderer/components/organisms/Radar/Radar.vue
@@ -71,7 +71,7 @@ import useDrawAntennaPosition from "@/renderer/components/organisms/Radar/useDra
 import useDrawRadar from "@/renderer/components/organisms/Radar/useDrawRadar";
 import useDrawSat from "@/renderer/components/organisms/Radar/useDrawSat";
 import { useStoreAutoState } from "@/renderer/store/useStoreAutoState";
-import { SatAzEl } from "@/renderer/types/satellite-type";
+import { RotatorAzEl, SatAzEl } from "@/renderer/types/satellite-type";
 import emitter from "@/renderer/util/EventBus";
 import { onMounted, Ref, ref, watch } from "vue";
 import useAutoTracking from "./useAutoTracking";
@@ -95,7 +95,7 @@ const props = defineProps({
 
 // データ
 const activeSatPos = ref<SatAzEl | null>(null);
-const antennaPos = ref<SatAzEl>();
+const antennaPos = ref<RotatorAzEl>();
 const currentDate = ref<Date>(props.currentDate);
 
 // 描画系データ
@@ -207,7 +207,6 @@ async function autoBtnClick() {
  */
 function azimuthFormat(value: SatAzEl | undefined) {
   if (!value) return "-";
-  if (value.az < 0 || value.el < 0) return "-";
 
   // Elevation > 90の場合はアンテナが反転しているので、Azimuth +180[deg]とする
   const azimuth = value.el > 90 ? value.az + 180 : value.az;
@@ -219,7 +218,6 @@ function azimuthFormat(value: SatAzEl | undefined) {
  */
 function elavationFormat(value: SatAzEl | undefined) {
   if (!value) return "-";
-  if (value.az < 0 || value.el < 0) return "-";
 
   // Elevation > 90の場合はアンテナが反転しているので、Elevation - 90[deg]とする
   const elevation = value.el > 90 ? 180 - value.el : value.el;

--- a/src/renderer/components/organisms/Radar/useDrawAntennaPosition.ts
+++ b/src/renderer/components/organisms/Radar/useDrawAntennaPosition.ts
@@ -1,4 +1,4 @@
-import { SatAzEl } from "@/renderer/types/satellite-type";
+import { RotatorAzEl } from "@/renderer/types/satellite-type";
 import { CenterPosition } from "@/renderer/util/CanvasUtil";
 import { Ref, watch } from "vue";
 
@@ -61,7 +61,7 @@ function useDrawAntennaPosition(
   canvasRef: Ref<HTMLCanvasElement | null>,
   radarRadius: number,
   radarCenter: CenterPosition,
-  position: Ref<SatAzEl | undefined>
+  position: Ref<RotatorAzEl | undefined>
 ) {
   watch(position, () => {
     const canvasElem = canvasRef.value;

--- a/src/renderer/types/satellite-type.ts
+++ b/src/renderer/types/satellite-type.ts
@@ -31,3 +31,9 @@ export type SatAzEl = {
   az: number;
   el: number;
 };
+
+// ローテータの位置（Deg）
+export type RotatorAzEl = {
+  az: number;
+  el: number;
+};


### PR DESCRIPTION
AZ、ELの値がマイナス値だった場合は"-"で表示していた。
ローテータから普通にマイナス値が送られてくるため、現在位置の表示として、その値をそのまま表示するようにした。