### PR TITLE
#14 TLEに説明文が入っていると読み込みエラーになるためフォーマットチェックを追加

### DIFF
--- a/src/main/service/TleService.ts
+++ b/src/main/service/TleService.ts
@@ -140,6 +140,22 @@ export default class TleService {
     // 各OSの改行コードを想定してスプリットする
     const lines = tlesText.split(/\r\n|\r|\n/).filter((line) => !CommonUtil.isEmpty(line.trim()));
     for (let ii = 0; ii < lines.length; ii += 3) {
+      // TLEの2行目が「1 」、3行目が「2 」で始まる行を探す
+      while (ii < lines.length) {
+        if (
+          lines[ii + 1] &&
+          lines[ii + 1].substring(0, 2) === "1 " &&
+          lines[ii + 2] &&
+          lines[ii + 2].substring(0, 2) === "2 "
+        ) {
+          break;
+        }
+        ii++;
+      }
+      // 行きすぎたらループを抜ける
+      if (lines.length <= ii + 2) break;
+
+      // ここまできたら取得可能なTLEの行数なので、TLEを取得する
       const id = TleUtil.getNoradId(lines[ii + 1]);
       const epoch = TleUtil.getEpochDate(lines[ii + 1]);
       const name = TleUtil.getName(lines[ii]);


### PR DESCRIPTION
# 前提
- 以下のフォーマットではないTLEの場合TLE読み込みに失敗する(前後に説明文が入ってても失敗する)
  - XXX
  - 1 XXXX
  - 2 XXXX

# 実装概要
- フォーマットチェックを行い「1 」「2 」が存在する行までスキップするようにした

# 注意点
- なし

# 関連
#14 