### PR TITLE
ICOM無線機で、Tx、Rx周波数が逆転する問題の対応

### DIFF
--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -211,39 +211,6 @@ export default class Constant {
 
     // ドップラーシフトが有効となるパス前後の追加時間範囲[単位:秒]
     static readonly DOPPLER_SHIFT_RANGE_SEC = 60;
-
-    /**
-     * CI-Vコマンド
-     */
-    public static readonly CivCommand = class {
-      // プリアンプル
-      static readonly PREAMBLE = 0xfe;
-      // ポストアンプル
-      static readonly POSTAMBLE = 0xfd;
-      // PCの送受信時アドレス
-      static readonly PC_ADDRESS = 0xe0;
-
-      // 周波数の設定(トランシーブ)
-      static readonly SET_FREQUENCY = 0x00; //0x05;
-      // 周波数の読み込み
-      static readonly GET_FREQUENCY = 0x03;
-      // モードの設定(非トランシーブ)
-      static readonly SET_MODE = 0x06; // 0x01;
-      // モードの読み込み
-      static readonly GET_MODE = 0x04;
-
-      // MAIN/SUBバンドの切り替え
-      static readonly SWITCH_BAND = 0x07;
-      // メインバンド
-      static readonly MAIN_BAND = 0xd0;
-      // サブバンド
-      static readonly SUB_BAND = 0xd1;
-      // メインバンドとサブバンドを入れ替える
-      static readonly INVERT_BAND = 0xb0;
-
-      // 連続するコマンドの結合を回避するためのパディング
-      static readonly PADDING = 0x00;
-    };
   };
 
   /**

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -179,12 +179,6 @@ export default class Constant {
    * 無線機関係
    */
   public static readonly Transceiver = class {
-    // コマンド送信タイミングの重複回避のため、互いに素なインターバル周期を設定する
-    // 無線機の周波数の読み取り間隔（ミリ秒）
-    static readonly GET_FREQUENCY_INTERVAL_MS = 700;
-    // 無線機の運用モードの読み取り間隔（ミリ秒）
-    static readonly GET_OPEMODE_INTERVAL_MS = 1900;
-
     /**
      * 無線機メーカーID
      */
@@ -230,11 +224,11 @@ export default class Constant {
       static readonly PC_ADDRESS = 0xe0;
 
       // 周波数の設定(トランシーブ)
-      static readonly SET_FREQUENCY = 0x00;
+      static readonly SET_FREQUENCY = 0x00; //0x05;
       // 周波数の読み込み
       static readonly GET_FREQUENCY = 0x03;
-      // モードの設定(トランシーブ)
-      static readonly SET_MODE = 0x01;
+      // モードの設定(非トランシーブ)
+      static readonly SET_MODE = 0x06; // 0x01;
       // モードの読み込み
       static readonly GET_MODE = 0x04;
 
@@ -244,6 +238,8 @@ export default class Constant {
       static readonly MAIN_BAND = 0xd0;
       // サブバンド
       static readonly SUB_BAND = 0xd1;
+      // メインバンドとサブバンドを入れ替える
+      static readonly INVERT_BAND = 0xb0;
 
       // 連続するコマンドの結合を回避するためのパディング
       static readonly PADDING = 0x00;

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -220,10 +220,17 @@ export function initializeIpcEvents() {
   });
 
   /**
+   * 無線機関係・無線機関係・AutoOn時の初期処理
+   */
+  ipcMain.handle("initAutoOn", async (event, txFreqHz: number, rxFreqHz: number) => {
+    return await TransceiverService.getInstance().initAutoOn(txFreqHz, rxFreqHz);
+  });
+
+  /**
    * 無線機関係・無線機周波数を変更する
    */
-  ipcMain.handle("setTransceiverFrequency", (event, frequencyModel: UplinkType | DownlinkType) => {
-    return TransceiverService.getInstance().setTransceiverFrequency(frequencyModel);
+  ipcMain.handle("setTransceiverFrequency", async (event, frequencyModel: UplinkType | DownlinkType) => {
+    return await TransceiverService.getInstance().setTransceiverFrequency(frequencyModel);
   });
 
   /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -117,7 +117,7 @@ function createWindow() {
   if (EnvUtil.isDev()) {
     // メインプロセス側のホットリロード設定
     // memo: メイン側のソース保存時に再起動させたくない場合は、ここをコメントアウトしてください
-    // enableHotReload();
+    enableHotReload();
 
     // ウィンドウ内のコンテンツの設定（レンダラプロセスのURLを指定）
     mainWindow.loadURL("http://localhost:5173");

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -117,7 +117,7 @@ function createWindow() {
   if (EnvUtil.isDev()) {
     // メインプロセス側のホットリロード設定
     // memo: メイン側のソース保存時に再起動させたくない場合は、ここをコメントアウトしてください
-    enableHotReload();
+    // enableHotReload();
 
     // ウィンドウ内のコンテンツの設定（レンダラプロセスのURLを指定）
     mainWindow.loadURL("http://localhost:5173");

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -199,6 +199,13 @@ const apiHandler = {
   },
 
   /**
+   * 無線機関係・AutoOn時の初期処理
+   */
+  initAutoOn: function (txFreqHz: number, rxFreqHz: number): Promise<ApiResponse<void>> {
+    return ipcRenderer.invoke("initAutoOn", txFreqHz, rxFreqHz);
+  },
+
+  /**
    * 無線機関係・周波数設定コマンドを送信する
    */
   setTransceiverFrequency: function (frequencyModel: UplinkType | DownlinkType): Promise<void> {

--- a/src/main/service/TransceiverSerivice.ts
+++ b/src/main/service/TransceiverSerivice.ts
@@ -81,6 +81,18 @@ export default class TransceiverService {
   }
 
   /**
+   * 無線機関係・AutoOn時の初期処理
+   */
+  public async initAutoOn(txFreqHz: number, rxFreqHz: number) {
+    if (!this.controller) {
+      return;
+    }
+
+    // AutoOnの初期処理を実行する
+    await this.controller.initAutoOn(txFreqHz, rxFreqHz);
+  }
+
+  /**
    * 無線機を変更する
    * @param transceiverConfig 無線機設定
    */
@@ -144,12 +156,12 @@ export default class TransceiverService {
    * 無線機周波数を変更する
    * @param {(UplinkType | DownlinkType)} frequencyModel 周波数設定
    */
-  public setTransceiverFrequency(frequencyModel: UplinkType | DownlinkType) {
+  public async setTransceiverFrequency(frequencyModel: UplinkType | DownlinkType) {
     if (!this.isReady()) {
       return;
     }
 
-    this.controller?.sendFrequencyCommand(frequencyModel);
+    await this.controller?.setFreq(frequencyModel);
   }
 
   /**
@@ -161,7 +173,7 @@ export default class TransceiverService {
       return;
     }
 
-    this.controller?.sendModeCommand(modeModel);
+    this.controller?.setMode(modeModel);
   }
 
   /**
@@ -173,7 +185,7 @@ export default class TransceiverService {
       return;
     }
 
-    this.controller?.sendSatelliteModeCommand(isSatelliteMode);
+    this.controller?.setSatelliteMode(isSatelliteMode);
   }
 
   /**

--- a/src/main/service/transceiver/controller/TransceiverControllerBase.ts
+++ b/src/main/service/transceiver/controller/TransceiverControllerBase.ts
@@ -5,7 +5,7 @@ import { ApiResponse } from "@/common/types/types";
  * 無線機のコントローラ親クラス
  */
 export default abstract class TransceiverControllerBase {
-  protected frequencyCallback: Function | null = null;
+  protected freqCallback: Function | null = null;
   protected modeCallback: Function | null = null;
 
   /**
@@ -19,28 +19,33 @@ export default abstract class TransceiverControllerBase {
   public abstract stop(): Promise<void>;
 
   /**
-   * 無線機に周波数を設定するコマンドを送信する
+   * 無線機関係・AutoOn時の初期処理
+   */
+  public abstract initAutoOn(txFreqHz: number, rxFreqHz: number): Promise<void>;
+
+  /**
+   * 無線機に送信する周波数を設定する
    * @param {(UplinkType | DownlinkType)} frequencyModel 周波数設定
    */
-  public abstract sendFrequencyCommand(frequencyModel: UplinkType | DownlinkType): Promise<void>;
+  public abstract setFreq(frequencyModel: UplinkType | DownlinkType): Promise<void>;
 
   /**
-   * 無線機に運用モードを設定するコマンドを送信する
+   * 無線機に送信する運用モードを設定する
    * @param {(UplinkType | DownlinkType)} modeModel 運用モード設定
    */
-  public abstract sendModeCommand(modeModel: UplinkType | DownlinkType): Promise<void>;
+  public abstract setMode(modeModel: UplinkType | DownlinkType): Promise<void>;
 
   /**
-   * 無線機にサテライトモードを設定するコマンドを送信する
+   * 無線機に送信するサテライトモードを設定する
    * @param {boolean} isSatelliteMode サテライトモード設定
    */
-  public abstract sendSatelliteModeCommand(isSatelliteMode: boolean): Promise<void>;
+  public abstract setSatelliteMode(isSatelliteMode: boolean): Promise<void>;
 
   /**
    * 無線機の周波数を呼び出し側に伝播させるためのコールバックを設定する
    */
   public setFrequencyCallback(callback: Function): void {
-    this.frequencyCallback = callback;
+    this.freqCallback = callback;
   }
 
   /**
@@ -54,7 +59,7 @@ export default abstract class TransceiverControllerBase {
    * コールバックを解除する
    */
   public unsetCallback(): void {
-    this.frequencyCallback = null;
+    this.freqCallback = null;
     this.modeCallback = null;
   }
 }

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -1,0 +1,210 @@
+import Constant from "@/common/Constant";
+
+/**
+ * ICOM無線機のコントローラ
+ */
+export default class TransceiverIcomCmdMaker {
+  /**
+   * トランシーブモードの設定コマンド
+   * @param onOff 0x00: Off, 0x01: On
+   */
+  public static setTranceive(civAddress: number, onOff: number): Uint8Array {
+    const data = new Uint8Array(11);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = 0x1a;
+    data[5] = 0x05;
+    data[6] = 0x01;
+    data[7] = 0x27;
+    data[8] = onOff;
+    data[9] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[10] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * VFO Aに切り替える
+   */
+  public static switchVfo(civAddress: number): Uint8Array {
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = 0x07;
+    data[5] = 0x00;
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機をメインバンドに切り替える
+   */
+  public static switchToMainBand(civAddress: number): Uint8Array {
+    // シリアル送信のデータ作成
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
+    data[5] = Constant.Transceiver.CivCommand.MAIN_BAND;
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機をサブバンドに切り替える
+   */
+  public static switchToSubBand(civAddress: number): Uint8Array {
+    // シリアル送信のデータ作成
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
+    data[5] = Constant.Transceiver.CivCommand.SUB_BAND;
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * メインバンドとサブバンドを入れ替える
+   */
+  public static setInvertBand(civAddress: number): Uint8Array {
+    // シリアル送信のデータ作成
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
+    data[5] = Constant.Transceiver.CivCommand.INVERT_BAND;
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機に周波数を設定するコマンドを送信する
+   */
+  public static setFreq(civAddress: number, freq: string): Uint8Array {
+    // 周波数を10桁の文字列に変換
+    const freqs = freq.padStart(10, "0").split("");
+    // シリアル送信用のデータを作成する
+    const data = new Uint8Array(12);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.SET_FREQUENCY;
+    data[5] = parseInt(freqs[8] + freqs[9], 16);
+    data[6] = parseInt(freqs[6] + freqs[7], 16);
+    data[7] = parseInt(freqs[4] + freqs[5], 16);
+    data[8] = parseInt(freqs[2] + freqs[3], 16);
+    data[9] = parseInt(freqs[0] + freqs[1], 16);
+    data[10] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[11] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機に運用モードを設定するコマンドを送信する
+   */
+  public static setMode(civAddress: number, mode: string): Uint8Array {
+    // シリアル送信用のデータを作成する
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.SET_MODE;
+    data[5] = parseInt(mode, 16);
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * サテライトモードの設定コマンド
+   * @param {boolean} isSatelliteMode サテライトモード設定
+   */
+  public static setSatelliteMode(civAddress: number, isSatelliteMode: boolean): Uint8Array {
+    const data = new Uint8Array(9);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = 0x16;
+    data[5] = 0x5a;
+    data[6] = isSatelliteMode ? 0x01 : 0x00;
+    data[7] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[8] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * サテライトモードの取得コマンド
+   */
+  public static getSatelliteMode(civAddress: number): Uint8Array {
+    const data = new Uint8Array(8);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = 0x16;
+    data[5] = 0x5a;
+    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機から現在の周波数を読み取るコマンドを送信する
+   */
+  public static getFreq(civAddress: number): Uint8Array {
+    // シリアル送信用のデータを作成する
+    const data = new Uint8Array(7);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.GET_FREQUENCY;
+    data[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+
+  /**
+   * 無線機から現在のモードを読み取るコマンドを送信する
+   */
+  public static getMode(civAddress: number): Uint8Array {
+    // シリアル送信用のデータを作成する
+    const data = new Uint8Array(7);
+    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[2] = civAddress;
+    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[4] = Constant.Transceiver.CivCommand.GET_MODE;
+    data[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
+    data[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+
+    return data;
+  }
+}

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -1,7 +1,38 @@
-import Constant from "@/common/Constant";
+/**
+ * CI-Vコマンド
+ */
+const CivCommand = class {
+  // プリアンプル
+  static readonly PREAMBLE = 0xfe;
+  // ポストアンプル
+  static readonly POSTAMBLE = 0xfd;
+  // PCの送受信時アドレス
+  static readonly PC_ADDRESS = 0xe0;
+
+  // 周波数の設定(トランシーブ)
+  static readonly SET_FREQUENCY = 0x00; //0x05;
+  // 周波数の読み込み
+  static readonly GET_FREQUENCY = 0x03;
+  // モードの設定(非トランシーブ)
+  static readonly SET_MODE = 0x06; // 0x01;
+  // モードの読み込み
+  static readonly GET_MODE = 0x04;
+
+  // MAIN/SUBバンドの切り替え
+  static readonly SWITCH_BAND = 0x07;
+  // メインバンド
+  static readonly MAIN_BAND = 0xd0;
+  // サブバンド
+  static readonly SUB_BAND = 0xd1;
+  // メインバンドとサブバンドを入れ替える
+  static readonly INVERT_BAND = 0xb0;
+
+  // 連続するコマンドの結合を回避するためのパディング
+  static readonly PADDING = 0x00;
+};
 
 /**
- * ICOM無線機のコントローラ
+ * ICOM無線機のコマンド生成クラス
  */
 export default class TransceiverIcomCmdMaker {
   /**
@@ -10,17 +41,17 @@ export default class TransceiverIcomCmdMaker {
    */
   public static setTranceive(civAddress: number, onOff: number): Uint8Array {
     const data = new Uint8Array(11);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[3] = CivCommand.PC_ADDRESS;
     data[4] = 0x1a;
     data[5] = 0x05;
     data[6] = 0x01;
     data[7] = 0x27;
     data[8] = onOff;
-    data[9] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[10] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[9] = CivCommand.POSTAMBLE;
+    data[10] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -30,14 +61,14 @@ export default class TransceiverIcomCmdMaker {
    */
   public static switchVfo(civAddress: number): Uint8Array {
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[3] = CivCommand.PC_ADDRESS;
     data[4] = 0x07;
     data[5] = 0x00;
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -48,14 +79,14 @@ export default class TransceiverIcomCmdMaker {
   public static switchToMainBand(civAddress: number): Uint8Array {
     // シリアル送信のデータ作成
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
-    data[5] = Constant.Transceiver.CivCommand.MAIN_BAND;
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.SWITCH_BAND;
+    data[5] = CivCommand.MAIN_BAND;
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -66,14 +97,14 @@ export default class TransceiverIcomCmdMaker {
   public static switchToSubBand(civAddress: number): Uint8Array {
     // シリアル送信のデータ作成
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
-    data[5] = Constant.Transceiver.CivCommand.SUB_BAND;
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.SWITCH_BAND;
+    data[5] = CivCommand.SUB_BAND;
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -84,14 +115,14 @@ export default class TransceiverIcomCmdMaker {
   public static setInvertBand(civAddress: number): Uint8Array {
     // シリアル送信のデータ作成
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
-    data[5] = Constant.Transceiver.CivCommand.INVERT_BAND;
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.SWITCH_BAND;
+    data[5] = CivCommand.INVERT_BAND;
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -104,18 +135,18 @@ export default class TransceiverIcomCmdMaker {
     const freqs = freq.padStart(10, "0").split("");
     // シリアル送信用のデータを作成する
     const data = new Uint8Array(12);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.SET_FREQUENCY;
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.SET_FREQUENCY;
     data[5] = parseInt(freqs[8] + freqs[9], 16);
     data[6] = parseInt(freqs[6] + freqs[7], 16);
     data[7] = parseInt(freqs[4] + freqs[5], 16);
     data[8] = parseInt(freqs[2] + freqs[3], 16);
     data[9] = parseInt(freqs[0] + freqs[1], 16);
-    data[10] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[11] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[10] = CivCommand.POSTAMBLE;
+    data[11] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -126,14 +157,14 @@ export default class TransceiverIcomCmdMaker {
   public static setMode(civAddress: number, mode: string): Uint8Array {
     // シリアル送信用のデータを作成する
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.SET_MODE;
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.SET_MODE;
     data[5] = parseInt(mode, 16);
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -144,15 +175,15 @@ export default class TransceiverIcomCmdMaker {
    */
   public static setSatelliteMode(civAddress: number, isSatelliteMode: boolean): Uint8Array {
     const data = new Uint8Array(9);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[3] = CivCommand.PC_ADDRESS;
     data[4] = 0x16;
     data[5] = 0x5a;
     data[6] = isSatelliteMode ? 0x01 : 0x00;
-    data[7] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[8] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[7] = CivCommand.POSTAMBLE;
+    data[8] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -162,14 +193,14 @@ export default class TransceiverIcomCmdMaker {
    */
   public static getSatelliteMode(civAddress: number): Uint8Array {
     const data = new Uint8Array(8);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
+    data[3] = CivCommand.PC_ADDRESS;
     data[4] = 0x16;
     data[5] = 0x5a;
-    data[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[6] = CivCommand.POSTAMBLE;
+    data[7] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -180,13 +211,13 @@ export default class TransceiverIcomCmdMaker {
   public static getFreq(civAddress: number): Uint8Array {
     // シリアル送信用のデータを作成する
     const data = new Uint8Array(7);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.GET_FREQUENCY;
-    data[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.GET_FREQUENCY;
+    data[5] = CivCommand.POSTAMBLE;
+    data[6] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }
@@ -197,13 +228,13 @@ export default class TransceiverIcomCmdMaker {
   public static getMode(civAddress: number): Uint8Array {
     // シリアル送信用のデータを作成する
     const data = new Uint8Array(7);
-    data[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    data[1] = Constant.Transceiver.CivCommand.PREAMBLE;
+    data[0] = CivCommand.PREAMBLE;
+    data[1] = CivCommand.PREAMBLE;
     data[2] = civAddress;
-    data[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    data[4] = Constant.Transceiver.CivCommand.GET_MODE;
-    data[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    data[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+    data[3] = CivCommand.PC_ADDRESS;
+    data[4] = CivCommand.GET_MODE;
+    data[5] = CivCommand.POSTAMBLE;
+    data[6] = CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
 
     return data;
   }

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -347,7 +347,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
         // 運用モードの値が取得できない場合は処理終了
         return;
       }
-      this.state.setReqRxMode(modeValue);
+      this.state.setReqTxMode(modeValue);
     } else if ("downlinkMode" in modeModel) {
       // ダウンリンクモードを取得する
       const mode = modeModel.downlinkMode;

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -1,41 +1,59 @@
 import CommonUtil from "@/common/CommonUtil";
-import Constant from "@/common/Constant";
-import I18nMsgs from "@/common/I18nMsgs";
+import { synchronized } from "@/common/decorator/synchronized";
 import { AppConfigTransceiver } from "@/common/model/AppConfigModel";
 import { DownlinkType, UplinkType } from "@/common/types/satelliteSettingTypes";
 import { ApiResponse } from "@/common/types/types";
+import TransceiverIcomCmdMaker from "@/main/service/transceiver/controller/TransceiverIcomCmdMaker";
+import TransceiverIcomRecvParser from "@/main/service/transceiver/controller/TransceiverIcomRecvParser";
+import TransceiverIcomState from "@/main/service/transceiver/controller/TransceiverIcomState";
 import TransceiverSerialControllerBase from "@/main/service/transceiver/controller/TransceiverSerialControllerBase";
 import AppMainLogger from "@/main/util/AppMainLogger";
 
 // 受信タイムアウト（秒）
-const RECV_TIEOUT_SEC = 10;
+// const RECV_TIEOUT_SEC = 10;
+
+// コマンド種別
+type CommandType = "GET_FREQ" | "GET_MODE" | "SET_FREQ" | "SET_MODE" | "SWITCH";
+
+// 受信コールバックの制御用
+type RecvCallBackType = {
+  reqCommandType: CommandType;
+  isResponsive: boolean;
+};
+
+// 無線機から応答があるコマンド種別
+const responsiveCmds = ["GET_FREQ", "GET_MODE", "SET_MODE", "SWITCH"];
 
 /**
  * ICOM無線機のコントローラ
  */
 export default class TransceiverIcomController extends TransceiverSerialControllerBase {
-  // 無線機の周波数取得用タイマー（setInterval向け）
-  private frequencyTimer: NodeJS.Timeout | null = null;
-  // 無線機の運用モード取得用タイマー（setInterval向け）
-  private opeModeTimer: NodeJS.Timeout | null = null;
+  // 無線機の操作タイマー（setInterval向け）
+  private sendAndRecvTimer: NodeJS.Timeout | null = null;
 
   // ICOM無線機のCI-Vアドレス
   private civAddress: number = 0;
-  // 無線機周波数のMAINバンド設定フラグ
-  private isMainFrequency = true;
-  // 無線機運用ノードのSUBバンド設定フラグ
-  private isMainMode = true;
-  // サテライトモード設定フラグ
-  private isSatelliteMode = false;
-  // 無線機から受信したデータ
-  private recvData = "";
 
-  // 受信タイムアウト制御用
-  private startSec = 0;
-  private isReceived = false;
+  // 無線機から受信したデータ
+  private recvBuffer = "";
+
+  // 無線機からの受信コールバック制御用
+  private recvCallbackType: RecvCallBackType | null = null;
+  private recvCallback: Function | null = null;
+
+  // RST側と無線機側の周波数、モードの状態の保持
+  private state = new TransceiverIcomState();
+
+  // // 受信タイムアウト制御用
+  // private startSec = 0;
+  // private isReceived = false;
+
+  // 無線機への送信間隔制御
+  private prevSendTimeMsec = 0;
 
   public constructor(transceiverConfig: AppConfigTransceiver) {
     super(transceiverConfig);
+    this.state.resetAll();
     this.civAddress = parseInt(transceiverConfig.civAddress.toLowerCase(), 16);
   }
 
@@ -43,22 +61,87 @@ export default class TransceiverIcomController extends TransceiverSerialControll
    * デバイスの接続を開始する
    */
   public override async start(): Promise<ApiResponse<void>> {
+    this.recvCallbackType = null;
+    this.recvCallback = null;
+
+    // シリアルオープン
     await this.openSerial();
 
-    // タイムアウト制御用
-    this.startSec = new Date().getTime() / 1000;
-    this.isReceived = false;
+    // // タイムアウト制御用
+    // this.startSec = new Date().getTime() / 1000;
+    // this.isReceived = false;
+
+    // 無線機の初期化
+    await this.initTranceiver();
+
+    // メイン/サブの処理を切り替える用
+    let isProcMain = true;
+    let isProcessing = false;
 
     // 一定間隔で無線機の周波数取得コマンドを送信する
-    this.frequencyTimer = setInterval(async () => {
-      await this.sendGetFrequencyCommand();
-    }, Constant.Transceiver.GET_FREQUENCY_INTERVAL_MS);
-    // 一定間隔で無線機のモード取得コマンドを送信する
-    this.opeModeTimer = setInterval(async () => {
-      await this.sendGetModeCommand();
-    }, Constant.Transceiver.GET_OPEMODE_INTERVAL_MS);
+    // 間隔が1秒の場合は、メイン0.5s、サブ0.5sで交互に処理を行う
+    const interval = (parseFloat(this.transceiverConfig.autoTrackingIntervalSec) * 1000) / 2;
+    this.sendAndRecvTimer = setInterval(async () => {
+      // 前回処理が終わっていない場合はスキップ
+      if (isProcessing) {
+        return;
+      }
+      isProcessing = true;
+
+      // データの送信と受信
+      await this.sendAndRecv(isProcMain);
+
+      // メイン、サブ切り替え
+      isProcMain = !isProcMain;
+      isProcessing = false;
+    }, interval);
+
+    AppMainLogger.info(`無線機の監視と送信準備完了。制御間隔：${this.transceiverConfig.autoTrackingIntervalSec}Sec`);
 
     return new ApiResponse(true);
+  }
+
+  /**
+   * 無線機の初期化を行う
+   */
+  private async initTranceiver() {
+    // VFO-Aに切り替え
+    const cmdData = TransceiverIcomCmdMaker.switchVfo(this.civAddress);
+    await this.sendAndWaitRecv(cmdData, "SWITCH");
+
+    // トランシーブOn
+    await this.sendAndWaitRecv(TransceiverIcomCmdMaker.setTranceive(this.civAddress, 0x01), "SWITCH");
+
+    // 無線機側のサテライトモードの取得
+    const recvData = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getSatelliteMode(this.civAddress), "GET_MODE");
+    this.state.isSatelliteMode = TransceiverIcomRecvParser.parseSatelliteMode(recvData);
+
+    // 現状の周波数データ取得
+    this.getIcomFreq();
+  }
+
+  /**
+   * 無線機側の周波数データを取得する
+   */
+  private async getIcomFreq() {
+    // メイン側のデータ取得
+    this.state.isMain = true;
+    await this.sendAndWaitRecv(TransceiverIcomCmdMaker.switchToMainBand(this.civAddress), "SWITCH");
+    // メイン・周波数
+    const recvDataMainFreq = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getFreq(this.civAddress), "GET_FREQ");
+    this.state.setRecvRxFreqHz(TransceiverIcomRecvParser.parseFreq(recvDataMainFreq));
+
+    // サテライトモードでない場合は、サブ側のデータ取得は不要
+    if (!this.state.isSatelliteMode) {
+      return;
+    }
+
+    // サブ側のデータ取得
+    this.state.isMain = false;
+    await this.sendAndWaitRecv(TransceiverIcomCmdMaker.switchToSubBand(this.civAddress), "SWITCH");
+    // メイン・周波数
+    const recvDataSubFreq = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getFreq(this.civAddress), "GET_FREQ");
+    this.state.setRecvTxFreqHz(TransceiverIcomRecvParser.parseFreq(recvDataSubFreq));
   }
 
   /**
@@ -74,246 +157,526 @@ export default class TransceiverIcomController extends TransceiverSerialControll
   }
 
   /**
-   * 無線機をメインバンドに切り替える
+   * AutoOn時の初期処理
    */
-  private async switchToMainBand(): Promise<void> {
-    // シリアル送信のデータ作成
-    const array = new Uint8Array(8);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
-    array[5] = Constant.Transceiver.CivCommand.MAIN_BAND;
-    array[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
-    // データ送信
-    await super.sendSerial(array);
+  public override async initAutoOn(txFreqHz: number, rxFreqHz: number): Promise<void> {
+    // メインバンドの周波数を元に、必要であればメインとサブの周波数帯の入れ替えを行う
+    await this.switchBandIfNeed();
   }
 
   /**
-   * 無線機をサブバンドに切り替える
+   * 定期コマンド送信を停止
    */
-  private async switchToSubBand(): Promise<void> {
-    // シリアル送信のデータ作成
-    const array = new Uint8Array(8);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.SWITCH_BAND;
-    array[5] = Constant.Transceiver.CivCommand.SUB_BAND;
-    array[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
+  private cancelTimer() {
+    // 定期コマンド送信を停止
+    if (this.sendAndRecvTimer) {
+      clearInterval(this.sendAndRecvTimer);
+
+      AppMainLogger.info(`無線機の監視とデータの送信を停止しました。`);
+    }
+  }
+
+  /**
+   * 無線機と送受信を行う
+   * @param isProcMain メインバンド側の処理か？
+   * @returns
+   */
+  @synchronized()
+  private async sendAndRecv(isProcMain: boolean) {
+    if (isProcMain) {
+      await this.sendAndRecvForMain();
+    }
+
+    // サテライトモードでない場合は、処理終了（サブバンドの処理は不要）
+    if (!this.state.isSatelliteMode) {
+      return;
+    }
+
+    if (!isProcMain) {
+      await this.sendAndRecvForSub();
+    }
+  }
+
+  /**
+   * メインバンドの周波数、モードを設定、取得する
+   */
+  private async sendAndRecvForMain() {
+    // メイン（Rx）の周波数、モードの更新がない場合は処理終了
+    if (!this.state.isRxUpdate()) {
+      return;
+    }
+
+    // メインへ切り替え
+    this.state.isMain = true;
+    await this.sendAndWaitRecv(TransceiverIcomCmdMaker.switchToMainBand(this.civAddress), "SWITCH");
+
+    // メインバンドの周波数を元に、必要であればメインとサブの周波数帯の入れ替えを行う
+    await this.switchBandIfNeed();
+
+    // Rx周波数の設定
+    if (this.state.isRxFreqUpdate) {
+      await this.sendRxFreq(this.state.getReqRxFreqHz());
+      this.state.isRxFreqUpdate = false;
+
+      // Rx周波数の取得
+      // memo: RST側から設定した場合は、基本的に同じ値が返ってくるため、周波数の取得は行わない
+    } else if (this.state.isRecvRxFreqUpdate) {
+      const recvDataMainFreq = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getFreq(this.civAddress), "GET_FREQ");
+      await this.handleRecvData(recvDataMainFreq);
+      this.state.isRecvRxFreqUpdate = false;
+    }
+
+    // Rx運用モードの設定
+    if (this.state.isRxModeUpdate) {
+      const cmdData = TransceiverIcomCmdMaker.setMode(this.civAddress, this.state.getReqRxMode());
+      await this.sendAndWaitRecv(cmdData, "SET_MODE");
+      this.state.isRxModeUpdate = false;
+    } else {
+      // Rx運用モードの取得
+      const recvDataMode = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getMode(this.civAddress), "GET_MODE");
+      await this.handleRecvData(recvDataMode);
+    }
+  }
+
+  /**
+   * サブバンドの周波数、モードを設定、取得する
+   */
+  private async sendAndRecvForSub() {
+    // サブ（Tx）の周波数、モードの更新がない場合は処理終了
+    if (!this.state.isTxUpdate()) {
+      return;
+    }
+
+    // サブバンドへ切り替え
+    this.state.isMain = false;
+    await this.sendAndWaitRecv(TransceiverIcomCmdMaker.switchToSubBand(this.civAddress), "SWITCH");
+
+    // Tx周波数の設定
+    if (this.state.isTxFreqUpdate) {
+      await this.sendTxFreq(this.state.getReqTxFreqHz());
+      this.state.isTxFreqUpdate = false;
+
+      // Rx周波数の取得
+      // memo: RST側から設定した場合は、基本的に同じ値が返ってくるため、周波数の取得は行わない
+    } else if (this.state.isRecvTxFreqUpdate) {
+      const recvDataSubFreq = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getFreq(this.civAddress), "GET_FREQ");
+      await this.handleRecvData(recvDataSubFreq);
+      this.state.isRecvTxFreqUpdate = false;
+    }
+
+    // Tx運用モードの設定
+    if (this.state.isTxModeUpdate) {
+      const cmdData = TransceiverIcomCmdMaker.setMode(this.civAddress, this.state.getReqTxMode());
+      await this.sendAndWaitRecv(cmdData, "SET_MODE");
+      this.state.isTxModeUpdate = false;
+    } else {
+      // Tx運用モードの取得
+      const recvDataMode = await this.sendAndWaitRecv(TransceiverIcomCmdMaker.getMode(this.civAddress), "GET_MODE");
+      await this.handleRecvData(recvDataMode);
+    }
+  }
+
+  /**
+   * Rx周波数の設定コマンドを送信する
+   */
+  private async sendRxFreq(freq: number): Promise<void> {
+    // 周波数が未設定の場合は処理終了する
+    if (!CommonUtil.isNumber(freq)) {
+      return;
+    }
 
     // データ送信
-    await super.sendSerial(array);
+    const freqStr = Math.floor(freq).toString();
+    const cmdData = TransceiverIcomCmdMaker.setFreq(this.civAddress, freqStr);
+    await this.sendAndWaitRecv(cmdData, "SET_FREQ");
+  }
+
+  /**
+   * Tx周波数の設定コマンドを送信する
+   */
+  private async sendTxFreq(freq: number): Promise<void> {
+    // 周波数が未設定の場合は処理終了する
+    if (!CommonUtil.isNumber(freq)) {
+      return;
+    }
+
+    // データ送信
+    const freqStr = Math.floor(freq).toString();
+    const cmdData = TransceiverIcomCmdMaker.setFreq(this.civAddress, freqStr);
+    await this.sendAndWaitRecv(cmdData, "SET_FREQ");
   }
 
   /**
    * 無線機に周波数を設定するコマンドを送信する
-   * @param {(UplinkType | DownlinkType)} frequencyModel 周波数設定
+   * @param {(UplinkType | DownlinkType)} freqModel 周波数設定
    */
-  public override async sendFrequencyCommand(frequencyModel: UplinkType | DownlinkType): Promise<void> {
+  public override async setFreq(freqModel: UplinkType | DownlinkType): Promise<void> {
     // シリアル未接続の場合は処理終了
     if (!this.serial?.isOpen) {
       AppMainLogger.warn("シリアル未接続のため、処理を終了します。");
       return;
     }
 
-    let frequency = "";
-    if ("uplinkHz" in frequencyModel && frequencyModel.uplinkHz) {
+    if ("uplinkHz" in freqModel && freqModel.uplinkHz) {
       // アップリンク周波数を取得する
-      frequency = Math.floor(frequencyModel.uplinkHz).toString();
+      this.state.setReqTxFreqHz(freqModel.uplinkHz);
 
-      // MAINバンドに切り替える
-      await this.switchToMainBand();
-    } else if ("downlinkHz" in frequencyModel && frequencyModel.downlinkHz) {
+      // await this.switchToMainBand();
+    } else if ("downlinkHz" in freqModel && freqModel.downlinkHz) {
       // ダウンリンク周波数を取得する
-      frequency = Math.floor(frequencyModel.downlinkHz).toString();
-
-      if (this.isSatelliteMode) {
-        // サテライトモードがONの場合はSUBバンドに切り替える
-        await this.switchToSubBand();
-      }
+      this.state.setReqRxFreqHz(freqModel.downlinkHz);
     }
-
-    if (CommonUtil.isEmpty(frequency)) {
-      // 周波数が未設定の場合は処理終了する
-      return;
-    }
-
-    // 周波数を10桁の文字列に変換
-    const frequencyArray = frequency.padStart(10, "0").split("");
-    // シリアル送信用のデータを作成する
-    const array = new Uint8Array(12);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.SET_FREQUENCY;
-    array[5] = parseInt(frequencyArray[8] + frequencyArray[9], 16);
-    array[6] = parseInt(frequencyArray[6] + frequencyArray[7], 16);
-    array[7] = parseInt(frequencyArray[4] + frequencyArray[5], 16);
-    array[8] = parseInt(frequencyArray[2] + frequencyArray[3], 16);
-    array[9] = parseInt(frequencyArray[0] + frequencyArray[1], 16);
-    array[10] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[11] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
-    // データ送信
-    await super.sendSerial(array);
   }
 
   /**
    * 無線機に運用モードを設定するコマンドを送信する
    * @param {(UplinkType | DownlinkType)} modeModel 運用モード設定
    */
-  public override async sendModeCommand(modeModel: UplinkType | DownlinkType): Promise<void> {
+  public override async setMode(modeModel: UplinkType | DownlinkType): Promise<void> {
     // シリアル未接続の場合は処理終了
     if (!this.serial?.isOpen) {
       AppMainLogger.warn("シリアル未接続のため、処理を終了します。");
       return;
     }
 
-    let mode = "";
     if ("uplinkMode" in modeModel) {
       // アップリンクモードを取得する
-      mode = modeModel.uplinkMode;
-
-      // MAINバンドに切り替える
-      await this.switchToMainBand();
+      const mode = modeModel.uplinkMode;
+      const modeValue = TransceiverIcomRecvParser.getValueFromOpeMode(mode);
+      if (modeValue === null) {
+        // 運用モードの値が取得できない場合は処理終了
+        return;
+      }
+      this.state.setReqRxMode(modeValue);
     } else if ("downlinkMode" in modeModel) {
       // ダウンリンクモードを取得する
-      mode = modeModel.downlinkMode;
-
-      if (this.isSatelliteMode) {
-        // サテライトモードがONの場合はSUBバンドに切り替える
-        await this.switchToSubBand();
+      const mode = modeModel.downlinkMode;
+      const modeValue = TransceiverIcomRecvParser.getValueFromOpeMode(mode);
+      if (modeValue === null) {
+        // 運用モードの値が取得できない場合は処理終了
+        return;
       }
+      this.state.setReqRxMode(modeValue);
     }
-
-    // 運用モードの値を取得
-    const modeValue = this.getValueFromOpeMode(mode);
-    if (modeValue === null) {
-      // 運用モードの値が取得できない場合は処理終了
-      return;
-    }
-
-    // シリアル送信用のデータを作成する
-    const array = new Uint8Array(8);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.SET_MODE;
-    array[5] = parseInt(modeValue, 16);
-    array[6] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[7] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
-    // データ送信
-    await super.sendSerial(array);
   }
 
   /**
-   * 運用モードの値を取得する
-   * @param {string} opeMode 運用モード
-   * @returns {(string | null)} 運用モードの値
+   * RSTと無線機のメインバンドの周波数を元に、必要であればバンドの入れ替えを行う
+   * memo: 入れ替えないと、要求と無線機のバンド帯が異なる場合に、周波数設定ができない
    */
-  private getValueFromOpeMode(opeMode: string): string | null {
-    switch (opeMode) {
-      case "LSB":
-        return "00";
-      case "USB":
-        return "01";
-      case "AM":
-        return "02";
-      case "CW":
-        return "03";
-      case "FM":
-        return "05";
-      case "DV":
-        return "17";
-      default:
-        return null;
+  private async switchBandIfNeed(): Promise<boolean> {
+    // サテライトモードでない場合は入れ替え不要
+    if (!this.state.isSatelliteMode) {
+      return false;
     }
+
+    const rstRxFreqHz = this.state.getReqRxFreqHz();
+    const icomRxFreqHz = this.state.getRecvRxFreqHz();
+
+    // 周波数が未設定の場合は入れ替え不要
+    if (rstRxFreqHz === 0 || icomRxFreqHz === 0) {
+      return false;
+    }
+
+    // RSTと無線機が144MHz帯か？
+    const isReq144Hz = 144000000 <= rstRxFreqHz && rstRxFreqHz <= 146000000;
+    const isNow144Hz = 144000000 <= icomRxFreqHz && icomRxFreqHz <= 146000000;
+    if (isReq144Hz && isNow144Hz) {
+      return false;
+    }
+
+    // RSTと無線機が430MHz帯か？
+    const isReq430Hz = 432000000 <= rstRxFreqHz && rstRxFreqHz <= 440000000;
+    const isNow430Hz = 432000000 <= icomRxFreqHz && icomRxFreqHz <= 440000000;
+    if (isReq430Hz && isNow430Hz) {
+      return false;
+    }
+
+    // RSTと無線機が12xxMHz帯か？
+    const isReq1200Hz = 1294000000 <= rstRxFreqHz && rstRxFreqHz <= 1295000000;
+    const isNow1200Hz = 1294000000 <= icomRxFreqHz && icomRxFreqHz <= 1295000000;
+    if (isReq1200Hz && isNow1200Hz) {
+      return false;
+    }
+
+    AppMainLogger.info(
+      `RSTと無線機のバンドが異なるため、無線機のメイン/サブバンドを反転させます。 RST=${rstRxFreqHz}Hz, ICOM=${icomRxFreqHz}Hz`
+    );
+
+    // メインとサブのバンドを入れ替える
+    const cmdData = TransceiverIcomCmdMaker.setInvertBand(this.civAddress);
+    await this.sendAndWaitRecv(cmdData, "SWITCH");
+
+    // 入れ替え後の周波数データを取得する
+    this.getIcomFreq();
+
+    return true;
   }
 
   /**
    * サテライトモードを設定するコマンドを送信する
    * @param {boolean} isSatelliteMode サテライトモード設定
    */
-  public override async sendSatelliteModeCommand(isSatelliteMode: boolean): Promise<void> {
+  public override async setSatelliteMode(isSatelliteMode: boolean): Promise<void> {
     // シリアル未接続の場合は処理終了
     if (!this.serial?.isOpen) {
       AppMainLogger.warn("シリアル未接続のため、処理を終了します。");
       return;
     }
 
-    // シリアル送信用のデータを作成する
-    const array = new Uint8Array(9);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = parseInt("16", 16);
-    array[5] = parseInt("5a", 16);
-    array[6] = isSatelliteMode ? parseInt("01", 16) : parseInt("00", 16);
-    array[7] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[8] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
     // データ送信
-    await super.sendSerial(array);
+    const cmdData = TransceiverIcomCmdMaker.setSatelliteMode(this.civAddress, isSatelliteMode);
+    await this.sendAndWaitRecv(cmdData, "SET_MODE");
+    // AppMainLogger.info(`送信 sendSatelliteModeCommand ${Buffer.from(cmdData).toString("hex")}`);
 
     // サテライトモードの設定を保持する
-    this.isSatelliteMode = isSatelliteMode;
+    this.state.isSatelliteMode = isSatelliteMode;
+
+    // メインバンドの周波数を元に、必要であればメインとサブの周波数帯の入れ替えを行う
+    await this.switchBandIfNeed();
+  }
+
+  /**
+   * 無線機へデータの送信、応答受信を行う
+   * 応答を待つかは、targetCmdTypeによって要否が決定させる
+   * @param cmdData コマンド
+   * @param targetCmdType 送信コマンド種別
+   * @returns 受信データ
+   */
+  @synchronized()
+  private async sendAndWaitRecv(cmdData: Uint8Array, targetCmdType: CommandType): Promise<string> {
+    // AppMainLogger.info(`sendAndWaitResponse ${targetCmdType} ` + Buffer.from(cmdData).toString("hex"));
+
+    return new Promise(async (resolve, reject) => {
+      // if (!this.checkRecvTimeout()) {
+      //   return;
+      // }
+
+      let timeout: NodeJS.Timeout;
+
+      const resetCallback = () => {
+        this.recvCallbackType = null;
+        clearTimeout(timeout);
+      };
+
+      // データ受信
+      const onData = (recvData: string, recvCmdType: string) => {
+        // AppMainLogger.info(`onData targetCmdType=${targetCmdType} recvCmdType=${recvCmdType} ${recvData}`);
+
+        if (!this.recvCallbackType) {
+          resetCallback();
+          resolve(recvData);
+          return;
+        }
+
+        if (CommonUtil.isEmpty(targetCmdType)) {
+          resetCallback();
+          resolve(recvData);
+          return;
+        }
+
+        // 送信と受信のコマンドが不一致の場合、無視
+        if (targetCmdType.startsWith("GET") && recvCmdType !== targetCmdType) {
+          return;
+        }
+
+        // 送信に対する受信が来たので、応答を返す
+        resetCallback();
+        resolve(recvData);
+      };
+
+      // コールバック制御データの作成
+      this.recvCallbackType = this.makeRecvCallback(targetCmdType);
+      this.recvCallback = null;
+      // 応答アリのコマンドの場合は、コールバックを設定する
+      if (this.recvCallbackType.isResponsive) {
+        this.recvCallback = onData;
+      }
+
+      // データ送信
+      // AppMainLogger.info(`sendAndWaitResponse send ${this.recvCallBack.reqCommandType}`);
+      await this.waitSendInterval();
+      await super.sendSerial(cmdData);
+
+      // 送信次点の現在の時刻を保持
+      this.prevSendTimeMsec = new Date().getTime();
+
+      // タイムアウト判定
+      timeout = setTimeout(() => {
+        // 応答タイムアウト時は、発生しうるためログ出力を行い、処理は継続する
+        AppMainLogger.warn(
+          `無線機からの応答タイムアウトが発生しました。 ${targetCmdType} コマンド：${Buffer.from(cmdData).toString("hex")}`
+        );
+
+        resetCallback();
+        resolve("");
+      }, 2000);
+
+      // 応答なしのコマンドは、送信後に解放する
+      if (!this.recvCallbackType.isResponsive) {
+        resetCallback();
+        resolve("");
+      }
+    });
+  }
+
+  /**
+   * 受信コールバックの制御データを作成する
+   */
+  private makeRecvCallback(reqCommandType: CommandType): RecvCallBackType {
+    return {
+      reqCommandType,
+      // 送信に対して応答があるコマンドか？
+      isResponsive: responsiveCmds.includes(reqCommandType),
+    };
   }
 
   /**
    * シリアルデータの受信
-   * @param {Buffer} data シリアルデータ
+   * memo: こちらは、無線機起点の受信データを処理する
+   * @param {Buffer} data 受信データ
    */
-  protected override onRecv = (data: Buffer) => {
-    if (!this.frequencyCallback || !this.modeCallback) {
+  protected override onRecv = async (data: Buffer) => {
+    if (!this.freqCallback || !this.modeCallback) {
       return;
     }
 
-    // 受信済みとする
-    this.isReceived = true;
+    // // 受信済みとする
+    // this.isReceived = true;
 
     // 受信データを16進数文字列に変換する
     for (let i = 0; i < data.length; i++) {
-      this.recvData += data[i].toString(16).padStart(2, "0").toLowerCase();
-      if (this.recvData.endsWith("fd")) {
-        // AppMainLogger.debug(`Serial 受信データ：${this.recvData}`);
-
-        // 無線機から受信したCI-Vコマンドを解析する
-        this.handleCivCommand(this.recvData);
-        this.recvData = "";
+      this.recvBuffer += data[i].toString(16).padStart(2, "0").toLowerCase();
+      if (!this.recvBuffer.endsWith("fd")) {
+        continue;
       }
+
+      // コールバックが設定されている場合は、ディスパッチにてコールバックを行う
+      if (this.recvCallbackType) {
+        this.dispatchRecvData(this.recvBuffer);
+      }
+      // 無線機起点で受信したデータの場合
+      else {
+        await this.handleRecvData(this.recvBuffer);
+      }
+
+      // 受信バッファをクリア
+      this.recvBuffer = "";
     }
   };
 
   /**
-   * 無線機から受信したCI-Vコマンドを処理する
+   * 無線機から受信したデータを処理する
    * @param {string} recvData 受信データ
    */
-  private handleCivCommand(recvData: string) {
-    switch (recvData.substring(8, 10)) {
+  private dispatchRecvData(recvData: string) {
+    if (!this.recvCallback) {
+      return;
+    }
+
+    // プリアンブルを読み捨て
+    const startIdx = recvData.indexOf("fefe");
+    const trimedData = recvData.substring(startIdx);
+
+    // 対象の無線機からの応答でない場合は無視（ターゲットのCI-Vアドレスで判定）
+    const target = trimedData.substring(6, 8);
+    if (target !== this.civAddress.toString(16)) {
+      return;
+    }
+
+    const resultCmd = trimedData.substring(8, 10);
+    // AppMainLogger.info(`  dispatchRecvData ${resultCmd} ${trimedData}`);
+
+    // コマンド部により処理を切り替え
+    switch (resultCmd) {
+      // セット系はコマンド部にFB（OK）、FA（NG）が返ってくる
+      case "fb":
+        //
+        this.recvCallback(trimedData, "SET_OK");
+        return;
+      case "fa":
+        this.recvCallback(trimedData, "SET_NG");
+        return;
+
+      // 周波数データの設定（トランシーブ）
       case "00":
+      // 表示周波数の取得
       case "03":
-        if (recvData.length === 22) {
-          // 無線機から受信した周波数データを処理する
-          this.receiveFrequencyData(recvData);
+        if (trimedData.length === 22) {
+          this.recvCallback(trimedData, "GET_FREQ");
         }
-        break;
+        return;
+
+      // 運用モードの設定（トランシーブ）
       case "01":
+      // 表示モードの取得
       case "04":
-        if (recvData.length === 16) {
-          // 無線機から受信した運用モードデータを処理する
-          this.receiveModeData(recvData);
+        if (trimedData.length === 16) {
+          this.recvCallback(trimedData, "GET_MODE");
         }
-        break;
+        return;
+    }
+
+    // サブコマンド部により処理を切り替え
+    const resultSubCmd = trimedData.substring(8, 12);
+    // AppMainLogger.info(`  dispatchRecvData ${resultSubCmd} ${trimedData}`);
+    switch (resultSubCmd) {
+      // サテライトモードの取得
+      case "165a":
+        this.recvCallback(trimedData, "GET_MODE");
+        return;
+    }
+
+    // 上記以外
+    this.recvCallback(trimedData, "");
+  }
+
+  /**
+   * 無線機から受信したデータを処理する
+   * @param {string} recvData 受信データ
+   */
+  private async handleRecvData(recvData: string) {
+    // プリアンブル以降を読む（先頭に"00"がついている場合があるので、そこは読み捨てる）
+    const startIdx = recvData.indexOf("fefe");
+    const trimedData = recvData.substring(startIdx);
+
+    // 対象の無線機からの応答でない場合は無視（ターゲットのCI-Vアドレスで判定）
+    const target = trimedData.substring(6, 8);
+    if (target !== this.civAddress.toString(16)) {
+      return;
+    }
+    // AppMainLogger.info(`  handleRecvData ${trimedData}`);
+
+    // コマンド部により処理を切り替え
+    switch (trimedData.substring(8, 10)) {
+      // 周波数データの設定（トランシーブ）
+      case "00":
+      // 表示周波数の取得
+      case "03":
+        if (trimedData.length === 22) {
+          // 無線機から受信した周波数データを処理する
+          await this.procRecvFreqData(trimedData);
+        }
+        return;
+
+      // 運用モードの設定（トランシーブ）
+      case "01":
+      // 表示モードの取得
+      case "04":
+        if (trimedData.length === 16) {
+          // 無線機から受信した運用モードデータを処理する
+          this.procRecvModeData(trimedData);
+        }
+        return;
+    }
+
+    // サブコマンド部を含めた処理切り替え
+    const resultSubCmd = trimedData.substring(8, 12);
+    switch (resultSubCmd) {
+      // サテライトモードの取得
+      case "165a":
+        // TODO: 画面にサテライトモードを返す
+        return;
     }
   }
 
@@ -321,81 +684,71 @@ export default class TransceiverIcomController extends TransceiverSerialControll
    * 無線機から受信した周波数データを処理する
    * @param {string} recvData 受信データ
    */
-  private receiveFrequencyData(recvData: string) {
-    if (!this.frequencyCallback) {
+  private async procRecvFreqData(recvData: string) {
+    if (!this.freqCallback) {
       return;
     }
 
+    // 受信データをパースして周波数部を読み取る
+    const freqHz = TransceiverIcomRecvParser.parseFreq(recvData);
     const res = new ApiResponse(true);
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合
-      if (this.isMainFrequency) {
-        // 周波数のMAINバンド設定フラグがTRUEの場合は受信データをアップリンク周波数とする
-        res.data = {
-          uplinkHz: this.getFrequencyFromRecvData(recvData),
-          uplinkMode: "",
-        } as UplinkType;
+
+    // サテライトモードがONの場合
+    if (this.state.isSatelliteMode) {
+      if (this.state.isMain) {
+        // メインバンドの受信データをRx周波数とする
+        res.data = { downlinkHz: freqHz, downlinkMode: "" } as DownlinkType;
+        this.state.setRecvRxFreqHz(freqHz);
       } else {
-        // 周波数のMAINバンド設定フラグがFALSEの場合は受信データをダウンリンク周波数とする
-        res.data = {
-          downlinkHz: this.getFrequencyFromRecvData(recvData),
-          downlinkMode: "",
-        } as DownlinkType;
+        // サブバンドは受信データをTx周波数とする
+        res.data = { uplinkHz: freqHz, uplinkMode: "" } as UplinkType;
+        this.state.setRecvTxFreqHz(freqHz);
       }
     } else {
-      // サテライトモードがOFFの場合で、周波数のMAINバンド設定フラグがTRUEの場合は受信データをアップリンク周波数とする
-      res.data = {
-        uplinkHz: this.getFrequencyFromRecvData(recvData),
-        uplinkMode: "",
-      } as UplinkType;
+      // サテライトモードがOFFの場合は、受信データをアップリンク周波数とする
+      res.data = { uplinkHz: freqHz, uplinkMode: "" } as UplinkType;
+      this.state.setRecvTxFreqHz(freqHz);
     }
 
     // 周波数のコールバック呼び出し
-    this.frequencyCallback(res);
-
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合はMAINバンド設定フラグを切り替える
-      this.isMainFrequency = !this.isMainFrequency;
-    } else {
-      // サテライトモードがOFFの場合はMAINバンドに固定する
-      this.isMainFrequency = true;
-    }
+    this.freqCallback(res);
   }
 
   /**
    * 無線機から受信した運用モードデータを処理する
    * @param {string} recvData 受信データ
    */
-  private receiveModeData(recvData: string) {
+  private procRecvModeData(recvData: string) {
     if (!this.modeCallback) {
       return;
     }
 
     const res = new ApiResponse(true);
     // 無線機から受信したデータから運用モードを取得する
-    const recvMode = this.getModeFromRecvData(recvData);
+    const recvMode = TransceiverIcomRecvParser.parseMode(recvData);
     if (!recvMode) {
       // 運用モードが取得できない場合は処理を中断する
       return;
     }
 
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合
-      if (this.isMainMode) {
-        // 運用モードのMAINバンド設定フラグがTRUEの場合は受信データをアップリンクの運用モードとする
-        res.data = {
-          uplinkHz: null,
-          uplinkMode: recvMode,
-        } as UplinkType;
-      } else {
+    // サテライトモードがONの場合
+    if (this.state.isSatelliteMode) {
+      if (this.state.isMain) {
         // 運用モードのMAINバンド設定フラグがFALSEの場合は受信データをダウンリンクの運用モードとする
         res.data = {
           downlinkHz: null,
           downlinkMode: recvMode,
         } as DownlinkType;
+      } else {
+        // 運用モードのMAINバンド設定フラグがTRUEの場合は受信データをアップリンクの運用モードとする
+        res.data = {
+          uplinkHz: null,
+          uplinkMode: recvMode,
+        } as UplinkType;
       }
+
+      // サテライトモードがOFFの場合は受信データをアップリンクの運用モードとする
     } else {
-      // サテライトモードがOFFの場合で、運用モードのMAINバンド設定フラグがTRUEの場合は受信データをアップリンクの運用モードとする
       res.data = {
         uplinkHz: null,
         uplinkMode: recvMode,
@@ -404,189 +757,52 @@ export default class TransceiverIcomController extends TransceiverSerialControll
 
     // 運用モードのコールバック呼び出し
     this.modeCallback(res);
-
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合はMAINバンド設定フラグを切り替える
-      this.isMainMode = !this.isMainMode;
-    } else {
-      // サテライトモードがOFFの場合はMAINバンドに固定する
-      this.isMainMode = true;
-    }
   }
+
+  // 一旦コメントアウト。もう不要かも？
+  // /**
+  //  * データ受信タイムアウトチェック
+  //  */
+  // private checkRecvTimeout(): boolean {
+  //   // 既にデータ受信済みであればOK
+  //   if (this.isReceived) {
+  //     return true;
+  //   }
+
+  //   // タイムアウト前の場合はOK
+  //   const nowSec = new Date().getTime() / 1000;
+  //   if (this.startSec + RECV_TIEOUT_SEC > nowSec) {
+  //     return true;
+  //   }
+
+  //   // タイムアウト
+  //   AppMainLogger.warn(
+  //     `無線機へのモード取得開始から${RECV_TIEOUT_SEC}秒経過しましたが、無線機から応答がないため、無線機のモードの取得を停止します。`
+  //   );
+
+  //   // タイマーを停止
+  //   this.cancelTimer();
+
+  //   // コールバック呼び出し
+  //   if (this.freqCallback) {
+  //     const res = new ApiResponse(false, I18nMsgs.SYSTEM_TRANSCEIVER_SERIAL_RECV_TIMEOUT);
+  //     this.freqCallback(res);
+  //   }
+  //   if (this.modeCallback) {
+  //     const res = new ApiResponse(false, I18nMsgs.SYSTEM_TRANSCEIVER_SERIAL_RECV_TIMEOUT);
+  //     this.modeCallback(res);
+  //   }
+
+  //   return false;
+  // }
 
   /**
-   * 無線機から受信したデータから周波数を取得する
-   * @param {string} recvData 受信データ
+   * 無線機への送信間隔を調整する
    */
-  private getFrequencyFromRecvData(recvData: string): number {
-    // 受信データから周波数部分を取得する
-    const dataArea = recvData.substring(10, 20);
-    const dataAreaArray = dataArea.split("");
-    const recvFrequencyStr =
-      dataAreaArray[8] +
-      dataAreaArray[9] +
-      dataAreaArray[6] +
-      dataAreaArray[7] +
-      dataAreaArray[4] +
-      dataAreaArray[5] +
-      dataAreaArray[2] +
-      dataAreaArray[3] +
-      dataAreaArray[0] +
-      dataAreaArray[1];
-
-    // 受信した周波数をGHzの数値に変換する
-    return parseInt(recvFrequencyStr);
-  }
-
-  /**
-   * 無線機から受信したデータから運用モードを取得する
-   * @param {string} recvData 受信データ
-   * @returns {string | null} 運用モード
-   */
-  private getModeFromRecvData(recvData: string): string | null {
-    // 受信データから運用モードを取得する
-    const recvMode = recvData.substring(10, 12);
-    switch (recvMode) {
-      case "00":
-        return Constant.Transceiver.OpeMode.LSB;
-      case "01":
-        return Constant.Transceiver.OpeMode.USB;
-      case "02":
-        return Constant.Transceiver.OpeMode.AM;
-      case "03":
-        return Constant.Transceiver.OpeMode.CW;
-      case "05":
-        return Constant.Transceiver.OpeMode.FM;
-      case "17":
-        return Constant.Transceiver.OpeMode.DV;
-      default:
-        return null;
-    }
-  }
-
-  /**
-   * 無線機から現在の周波数を読み取るコマンドを送信する
-   */
-  private async sendGetFrequencyCommand(): Promise<void> {
-    if (!this.checkRecvTimeout()) {
-      return;
-    }
-
-    if (!this.serial) {
-      return;
-    }
-
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合
-      if (this.isMainFrequency) {
-        // 周波数のMAINバンド設定フラグがTRUEの場合はMAINバンドに切り替える
-        this.switchToMainBand();
-      } else {
-        // 周波数のMAINバンド設定フラグがFALSEの場合はSUBバンドに切り替える
-        this.switchToSubBand();
-      }
-    } else {
-      // サテライトモードがOFFの場合はMAINバンドに固定する
-      this.switchToMainBand();
-    }
-
-    // シリアル送信用のデータを作成する
-    const array = new Uint8Array(7);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.GET_FREQUENCY;
-    array[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
-    // データ送信
-    await super.sendSerial(array);
-  }
-
-  /**
-   * 無線機から現在のモードを読み取るコマンドを送信する
-   */
-  private async sendGetModeCommand(): Promise<void> {
-    if (!this.checkRecvTimeout()) {
-      return;
-    }
-
-    if (!this.serial) {
-      return;
-    }
-
-    if (this.isSatelliteMode) {
-      // サテライトモードがONの場合
-      if (this.isMainMode) {
-        // 運用モードのMAINバンド設定フラグがTRUEの場合はMAINバンドに切り替える
-        this.switchToMainBand();
-      } else {
-        // 運用モードのMAINバンド設定フラグがFALSEの場合はSUBバンドに切り替える
-        this.switchToSubBand();
-      }
-    } else {
-      // サテライトモードがOFFの場合はMAINバンドに固定する
-      this.switchToMainBand();
-    }
-
-    // シリアル送信用のデータを作成する
-    const array = new Uint8Array(7);
-    array[0] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[1] = Constant.Transceiver.CivCommand.PREAMBLE;
-    array[2] = this.civAddress;
-    array[3] = Constant.Transceiver.CivCommand.PC_ADDRESS;
-    array[4] = Constant.Transceiver.CivCommand.GET_MODE;
-    array[5] = Constant.Transceiver.CivCommand.POSTAMBLE;
-    array[6] = Constant.Transceiver.CivCommand.PADDING; // 後続コマンドとの結合を回避するためのパディング
-
-    // データ送信
-    await super.sendSerial(array);
-  }
-
-  private cancelTimer() {
-    // 定期コマンド送信を停止
-    if (this.frequencyTimer) {
-      clearInterval(this.frequencyTimer);
-    }
-    if (this.opeModeTimer) {
-      clearInterval(this.opeModeTimer);
-    }
-  }
-
-  /**
-   * データ受信タイムアウトチェック
-   */
-  private checkRecvTimeout(): boolean {
-    // 既にデータ受信済みであればOK
-    if (this.isReceived) {
-      return true;
-    }
-
-    // タイムアウト前の場合はOK
-    const nowSec = new Date().getTime() / 1000;
-    if (this.startSec + RECV_TIEOUT_SEC > nowSec) {
-      return true;
-    }
-
-    // タイムアウト
-    AppMainLogger.warn(
-      `無線機のモード取得開始から${RECV_TIEOUT_SEC}秒経過しましたが、無線機から応答がないため、無線機のモードの取得を停止します。`
-    );
-
-    // タイマーを停止
-    this.cancelTimer();
-
-    // コールバック呼び出し
-    if (this.frequencyCallback) {
-      const res = new ApiResponse(false, I18nMsgs.SYSTEM_TRANSCEIVER_SERIAL_RECV_TIMEOUT);
-      this.frequencyCallback(res);
-    }
-    if (this.modeCallback) {
-      const res = new ApiResponse(false, I18nMsgs.SYSTEM_TRANSCEIVER_SERIAL_RECV_TIMEOUT);
-      this.modeCallback(res);
-    }
-
-    return false;
+  private async waitSendInterval() {
+    // memo: 現状、特に調整しなくても問題なしのため、コメントアウト
+    // const now = new Date().getTime();
+    // const interval = now - this.prevSendTimeMsec;
+    // await CommonUtil.sleep(interval + 10);
   }
 }

--- a/src/main/service/transceiver/controller/TransceiverIcomRecvParser.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomRecvParser.ts
@@ -1,0 +1,92 @@
+import Constant from "@/common/Constant";
+
+/**
+ * ICOM無線機からの応答データパーサ
+ */
+export default class TransceiverIcomRecvParser {
+  /**
+   * 無線機から受信したデータから周波数を取得する
+   * @param {string} recvData 受信データ
+   */
+  public static parseFreq(recvData: string): number {
+    // 受信データから周波数部分を取得する
+    const dataArea = recvData.substring(10, 20);
+    const dataAreaArray = dataArea.split("");
+    const recvFrequencyStr =
+      dataAreaArray[8] +
+      dataAreaArray[9] +
+      dataAreaArray[6] +
+      dataAreaArray[7] +
+      dataAreaArray[4] +
+      dataAreaArray[5] +
+      dataAreaArray[2] +
+      dataAreaArray[3] +
+      dataAreaArray[0] +
+      dataAreaArray[1];
+
+    return parseInt(recvFrequencyStr);
+  }
+
+  /**
+   * 運用モードの値を取得する
+   * @param {string} opeMode 運用モード
+   * @returns {(string | null)} 運用モードの値
+   */
+  public static getValueFromOpeMode(opeMode: string): string | null {
+    switch (opeMode) {
+      case "LSB":
+        return "00";
+      case "USB":
+        return "01";
+      case "AM":
+        return "02";
+      case "CW":
+        return "03";
+      case "FM":
+        return "05";
+      case "DV":
+        return "17";
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * 無線機から受信したデータから運用モードを取得する
+   * @param {string} recvData 受信データ
+   * @returns {string | null} 運用モード
+   */
+  public static parseMode(recvData: string): string | null {
+    // 受信データから運用モードを取得する
+    const recvMode = recvData.substring(10, 12);
+    switch (recvMode) {
+      case "00":
+        return Constant.Transceiver.OpeMode.LSB;
+      case "01":
+        return Constant.Transceiver.OpeMode.USB;
+      case "02":
+        return Constant.Transceiver.OpeMode.AM;
+      case "03":
+        return Constant.Transceiver.OpeMode.CW;
+      case "05":
+        return Constant.Transceiver.OpeMode.FM;
+      case "17":
+        return Constant.Transceiver.OpeMode.DV;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * 無線機から受信したサテライトモードの応答をパースする
+   * @param {string} recvData 受信データ
+   * @returns true: サテライトモードOn
+   */
+  public static parseSatelliteMode(recvData: string): boolean {
+    const recvMode = recvData.substring(13, 15);
+    if (recvMode === "01") {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/service/transceiver/controller/TransceiverIcomState.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomState.ts
@@ -40,49 +40,75 @@ export default class TransceiverIcomState {
   }
 
   /**
-   * RSTから無線機に設定したい周波数をセットする
+   * RSTから無線機に設定したいRx周波数をセットする
    */
   public setReqRxFreqHz(freqHz: number): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.reqRxFreqHz === freqHz) {
+      return;
+    }
     this.reqRxFreqHz = freqHz;
     this.isRxFreqUpdate = true;
   }
+
+  /**
+   * RSTから無線機に設定したいTx周波数をセットする
+   */
   public setReqTxFreqHz(freq: number): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.reqTxFreqHz === freq) {
+      return;
+    }
     this.reqTxFreqHz = freq;
     this.isTxFreqUpdate = true;
   }
 
   /**
-   * RSTから無線機に設定したいモードをセットする
+   * RSTから無線機に設定したいRxモードをセットする
    */
   public setReqRxMode(mode: string): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.reqRxMode === mode) {
+      return;
+    }
     this.reqRxMode = mode;
     this.isRxModeUpdate = true;
   }
+
+  /**
+   * RSTから無線機に設定したいTxモードをセットする
+   */
   public setReqTxMode(mode: string): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.reqTxMode === mode) {
+      return;
+    }
     this.reqTxMode = mode;
     this.isTxModeUpdate = true;
   }
 
   /**
-   * 無線機から取得した周波数をセットする
+   * 無線機から取得したRx周波数をセットする
    */
   public setRecvRxFreqHz(freq: number): void {
     // 現在保持している値と同一の場合は何もしない
     if (this.recvRxFreqHz === freq) {
       return;
     }
-
     this.recvRxFreqHz = freq;
     this.isRecvRxFreqUpdate = true;
     // 無線機での周波数変更は片側の変更のみが通知されるため、Tx側の周波数も更新されたものとして、データ取得対象としておく
     this.isRecvTxFreqUpdate = true;
   }
+
+  /**
+   * 無線機から取得したTx周波数をセットする
+   */
   public setRecvTxFreqHz(freq: number): void {
     // 現在保持している値と同一の場合は何もしない
     if (this.recvTxFreqHz === freq) {
       return;
     }
-
     this.recvTxFreqHz = freq;
     this.isRecvTxFreqUpdate = true;
     // 無線機での周波数変更は片側の変更のみが通知されるため、Rx側の周波数も更新されたものとして、データ取得対象としておく

--- a/src/main/service/transceiver/controller/TransceiverIcomState.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomState.ts
@@ -1,0 +1,140 @@
+/**
+ * RSTとICOM無線機の周波数とモードの値と更新状態を保持するクラス
+ */
+export default class TransceiverIcomState {
+  // バンドの状態
+  public isMain = true;
+  // サテライトモード
+  public isSatelliteMode = false;
+
+  // 無線機に設定したい周波数、モード
+  private reqRxFreqHz = 0;
+  private reqTxFreqHz = 0;
+  private reqRxMode = "";
+  private reqTxMode = "";
+
+  // 無線機から取得した周波数
+  private recvTxFreqHz = 0;
+  private recvRxFreqHz = 0;
+
+  // 更新フラグ
+  public isTxFreqUpdate = false;
+  public isRxFreqUpdate = false;
+  public isRxModeUpdate = false;
+  public isTxModeUpdate = false;
+  public isRecvTxFreqUpdate = false;
+  public isRecvRxFreqUpdate = false;
+
+  /**
+   * Rx（メインバンド）の周波数、モードが更新されているかを返す
+   */
+  public isRxUpdate(): boolean {
+    return this.isRxFreqUpdate || this.isRxModeUpdate || this.isRecvRxFreqUpdate;
+  }
+
+  /**
+   * Tx（サブバンド）の周波数、モードが更新されているかを返す
+   */
+  public isTxUpdate(): boolean {
+    return this.isTxFreqUpdate || this.isTxModeUpdate || this.isRecvTxFreqUpdate;
+  }
+
+  /**
+   * RSTから無線機に設定したい周波数をセットする
+   */
+  public setReqRxFreqHz(freqHz: number): void {
+    this.reqRxFreqHz = freqHz;
+    this.isRxFreqUpdate = true;
+  }
+  public setReqTxFreqHz(freq: number): void {
+    this.reqTxFreqHz = freq;
+    this.isTxFreqUpdate = true;
+  }
+
+  /**
+   * RSTから無線機に設定したいモードをセットする
+   */
+  public setReqRxMode(mode: string): void {
+    this.reqRxMode = mode;
+    this.isRxModeUpdate = true;
+  }
+  public setReqTxMode(mode: string): void {
+    this.reqTxMode = mode;
+    this.isTxModeUpdate = true;
+  }
+
+  /**
+   * 無線機から取得した周波数をセットする
+   */
+  public setRecvRxFreqHz(freq: number): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.recvRxFreqHz === freq) {
+      return;
+    }
+
+    this.recvRxFreqHz = freq;
+    this.isRecvRxFreqUpdate = true;
+    // 無線機での周波数変更は片側の変更のみが通知されるため、Tx側の周波数も更新されたものとして、データ取得対象としておく
+    this.isRecvTxFreqUpdate = true;
+  }
+  public setRecvTxFreqHz(freq: number): void {
+    // 現在保持している値と同一の場合は何もしない
+    if (this.recvTxFreqHz === freq) {
+      return;
+    }
+
+    this.recvTxFreqHz = freq;
+    this.isRecvTxFreqUpdate = true;
+    // 無線機での周波数変更は片側の変更のみが通知されるため、Rx側の周波数も更新されたものとして、データ取得対象としておく
+    this.isRecvRxFreqUpdate = true;
+  }
+
+  /**
+   * Rx（メインバンド）の周波数、モードの更新状態をリセットする
+   */
+  public resetRx(): void {
+    this.isRxFreqUpdate = false;
+    this.isRxModeUpdate = false;
+    this.isRecvRxFreqUpdate = false;
+    this.isRecvTxFreqUpdate = false;
+  }
+
+  /**
+   * Tx（サブバンド）の周波数、モードの更新状態をリセットする
+   */
+  public resetTx(): void {
+    this.reqTxMode = "";
+    this.isTxFreqUpdate = false;
+    this.isTxModeUpdate = false;
+    this.isRecvTxFreqUpdate = false;
+    this.isRecvRxFreqUpdate = false;
+  }
+
+  /**
+   * 周波数、モードの更新状態をリセットする
+   */
+  public resetAll(): void {
+    this.resetRx();
+    this.resetTx();
+  }
+
+  // Getter
+  public getRecvRxFreqHz(): number {
+    return this.recvRxFreqHz;
+  }
+  public getRecvTxFreqHz(): number {
+    return this.recvTxFreqHz;
+  }
+  public getReqRxFreqHz(): number {
+    return this.reqRxFreqHz;
+  }
+  public getReqTxFreqHz(): number {
+    return this.reqTxFreqHz;
+  }
+  public getReqRxMode(): string {
+    return this.reqRxMode;
+  }
+  public getReqTxMode(): string {
+    return this.reqTxMode;
+  }
+}

--- a/src/main/service/transceiver/controller/TransceiverIcomState.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomState.ts
@@ -43,7 +43,7 @@ export default class TransceiverIcomState {
    * RSTから無線機に設定したいRx周波数をセットする
    */
   public setReqRxFreqHz(freqHz: number): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.reqRxFreqHz === freqHz) {
       return;
     }
@@ -55,7 +55,7 @@ export default class TransceiverIcomState {
    * RSTから無線機に設定したいTx周波数をセットする
    */
   public setReqTxFreqHz(freq: number): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.reqTxFreqHz === freq) {
       return;
     }
@@ -67,7 +67,7 @@ export default class TransceiverIcomState {
    * RSTから無線機に設定したいRxモードをセットする
    */
   public setReqRxMode(mode: string): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.reqRxMode === mode) {
       return;
     }
@@ -79,7 +79,7 @@ export default class TransceiverIcomState {
    * RSTから無線機に設定したいTxモードをセットする
    */
   public setReqTxMode(mode: string): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.reqTxMode === mode) {
       return;
     }
@@ -91,7 +91,7 @@ export default class TransceiverIcomState {
    * 無線機から取得したRx周波数をセットする
    */
   public setRecvRxFreqHz(freq: number): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.recvRxFreqHz === freq) {
       return;
     }
@@ -105,7 +105,7 @@ export default class TransceiverIcomState {
    * 無線機から取得したTx周波数をセットする
    */
   public setRecvTxFreqHz(freq: number): void {
-    // 現在保持している値と同一の場合は何もしない
+    // 現在保持している値と同一の場合は何もしない（不要なバンド切り替えを抑止する）
     if (this.recvTxFreqHz === freq) {
       return;
     }

--- a/src/main/service/transceiver/controller/TransceiverSerialControllerBase.ts
+++ b/src/main/service/transceiver/controller/TransceiverSerialControllerBase.ts
@@ -37,8 +37,9 @@ export default abstract class TransceiverSerialControllerBase extends Transceive
   /**
    * データ受信
    */
-  protected onRecv(data: Buffer): void {
+  protected onRecv(data: Buffer): Promise<void> {
     // console.log(`受信データ: ${data.toString()}`);
+    return Promise.resolve();
   }
 
   /**

--- a/src/renderer/api/ApiTransceiver.ts
+++ b/src/renderer/api/ApiTransceiver.ts
@@ -22,6 +22,13 @@ export default class ApiTransceiver {
   }
 
   /**
+   * AutoOn時の初期処理
+   */
+  public static async initAutoOn(txFreqHz: number, rxFreqHz: number): Promise<void> {
+    await window.rstApi.initAutoOn(txFreqHz, rxFreqHz);
+  }
+
+  /**
    * 指定の周波数に変更する
    */
   public static async setTransceiverFrequency(frequencyModel: UplinkType | DownlinkType) {

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -95,6 +95,12 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       await updateRxModeFlags(rxOpeMode.value);
     }
 
+    // Auto開始をメイン側に連携する
+    await ApiTransceiver.initAutoOn(
+      TransceiverUtil.mhzToHz(parseInt(txFrequency.value)),
+      TransceiverUtil.mhzToHz(parseInt(rxFrequency.value))
+    );
+
     // ドップラーシフトの基準周波数を設定する
     dopplerTxBaseFrequency.value = Number(txFrequency.value);
     dopplerRxBaseFrequency.value = Number(rxFrequency.value);

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverConn/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverConn/useTransceiverCtrl.ts
@@ -23,7 +23,7 @@ export default function useTransceiverCtrl(form: Ref<TransceiverConnForm>) {
     // 無線機が指定されている場合は、無線機の監視を開始する
     const tranConfig = createTransceiverConfig();
     if (!CommonUtil.isEmpty(tranConfig.transceiverId)) {
-      await ApiTransceiver.startCtrl(tranConfig);
+      await ApiTransceiver.startCtrl();
     }
   }
 

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverConn/useTransceiverTestConnect.ts
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverConn/useTransceiverTestConnect.ts
@@ -54,8 +54,8 @@ export default function useTransceiverTestConnect(
       return;
     }
 
-    // 接続開始
-    await startNewConnect();
+    // テスト後はクローズする
+    await ApiSirial.close();
 
     loadingTestBtn.value = false;
     isSerialOpen.value = true;


### PR DESCRIPTION
ICOMのメインバンドはRx、サブバンドはTxのため、それに合わせてバンド指定して周波数を送信するようにした。

また、以下の改善を行った。
- 画面での周波数変更と、無線機側での変更について、同期処理の交通整理のため、Auto時を含む画面からの周波数変更時は、当該値を保持し、設定間隔ごとに周波数を無線機に送信する。運用モードも同様の処理としている。
- コマンドの生成を別クラスに抽出（TransceiverIcomCmdMaker）
- 無線機からのデータのパーサを別クラスに抽出（TransceiverIcomRecvParser）
