### PR TITLE
IC910のサテライトモード対応

### DIFF
--- a/resources/data/init-data/transceiver.json
+++ b/resources/data/init-data/transceiver.json
@@ -15,6 +15,11 @@
           "civAddress": "A2"
         },
         {
+          "transceiverId": "4",
+          "deviceName": "IC-910",
+          "civAddress": "60"
+        },
+        {
           "transceiverId": "3",
           "deviceName": "ID-52",
           "civAddress": "A6"

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -190,6 +190,14 @@ export default class Constant {
     };
 
     /**
+     * 機種ID
+     */
+    public static readonly TransceiverId = class {
+      // ICOM IC-910
+      static readonly ICOM_IC910 = "4";
+    };
+
+    /**
      * 無線機運用モード
      */
     public static readonly OpeMode = class {

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -1,3 +1,5 @@
+import Constant from "@/common/Constant";
+
 /**
  * CI-Vコマンド
  */
@@ -36,9 +38,11 @@ const CivCommand = class {
  */
 export default class TransceiverIcomCmdMaker {
   private civAddress: number = 0x0;
+  private transceiverId: string = "";
 
-  public constructor(civAddress: number) {
+  public constructor(civAddress: number, transceiverId: string) {
     this.civAddress = civAddress;
+    this.transceiverId = transceiverId;
   }
 
   /**
@@ -167,11 +171,16 @@ export default class TransceiverIcomCmdMaker {
    * @param {boolean} isSatelliteMode サテライトモード設定
    */
   public setSatelliteMode(isSatelliteMode: boolean): Uint8Array {
+    // IC910の場合は、コマンドが異なる
+    let cmd = [0x16, 0x5a]; // IC910以外の機種
+    if (this.transceiverId === Constant.Transceiver.TransceiverId.ICOM_IC910) {
+      cmd = [0x1a, 0x07];
+    }
+
     return new Uint8Array([
       ...this.makePrefix(),
       // コマンド部
-      0x16, // サテライトモードの設定
-      0x5a,
+      ...cmd,
       isSatelliteMode ? 0x01 : 0x00,
       ...this.makeSuffix(),
     ]);
@@ -181,11 +190,16 @@ export default class TransceiverIcomCmdMaker {
    * サテライトモードの取得コマンド
    */
   public getSatelliteMode(): Uint8Array {
+    // IC910の場合は、コマンドが異なる
+    let cmd = [0x16, 0x5a]; // IC910以外の機種
+    if (this.transceiverId === Constant.Transceiver.TransceiverId.ICOM_IC910) {
+      cmd = [0x1a, 0x07];
+    }
+
     return new Uint8Array([
       ...this.makePrefix(),
       // コマンド部
-      0x16, // サテライトモードの設定
-      0x5a,
+      ...cmd,
       ...this.makeSuffix(),
     ]);
   }

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -58,7 +58,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     super(transceiverConfig);
     this.state.resetAll();
     this.civAddress = parseInt(transceiverConfig.civAddress.toLowerCase(), 16);
-    this.cmdMaker = new TransceiverIcomCmdMaker(this.civAddress);
+    this.cmdMaker = new TransceiverIcomCmdMaker(this.civAddress, transceiverConfig.transceiverId);
   }
 
   /**


### PR DESCRIPTION
#39 対応
- 機種に基づき、生成するサテライトモード設定のコマンドを変更させる。
　IC-910：1A07 でOFF/ON
　IC-910以外：165A でOFF/ON
