### PR TITLE
ICOM無線機に送信する周波数がアマチュア無線の周波数帯以外の場合に、バンド入れ替えをし続ける挙動を改善

### DIFF
--- a/src/__tests__/common/TransceiverUtil_analizeAmateurBandRange.test.ts
+++ b/src/__tests__/common/TransceiverUtil_analizeAmateurBandRange.test.ts
@@ -1,0 +1,44 @@
+import TransceiverUtil from "@/common/util/TransceiverUtil";
+
+describe("TransceiverUtil.analizeAmateurBandRangeのテスト", () => {
+  test("null_undefined系", () => {
+    expect(TransceiverUtil.analizeAmateurBandRange(null!)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(undefined!)).toBe("");
+  });
+
+  test("144MHz帯", () => {
+    expect(TransceiverUtil.analizeAmateurBandRange(143999999)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(144000000)).toBe("144");
+    expect(TransceiverUtil.analizeAmateurBandRange(144000001)).toBe("144");
+
+    expect(TransceiverUtil.analizeAmateurBandRange(145999999)).toBe("144");
+    expect(TransceiverUtil.analizeAmateurBandRange(146000000)).toBe("144");
+    expect(TransceiverUtil.analizeAmateurBandRange(146000001)).toBe("");
+  });
+
+  test("430MHz帯", () => {
+    expect(TransceiverUtil.analizeAmateurBandRange(431999999)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(432000000)).toBe("430");
+    expect(TransceiverUtil.analizeAmateurBandRange(432000001)).toBe("430");
+
+    expect(TransceiverUtil.analizeAmateurBandRange(439999999)).toBe("430");
+    expect(TransceiverUtil.analizeAmateurBandRange(440000000)).toBe("430");
+    expect(TransceiverUtil.analizeAmateurBandRange(440000001)).toBe("");
+  });
+
+  test("1.2GHz帯", () => {
+    expect(TransceiverUtil.analizeAmateurBandRange(1293999999)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(1294000000)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1294000001)).toBe("1200");
+
+    expect(TransceiverUtil.analizeAmateurBandRange(1294999999)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1295000000)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1295000001)).toBe("");
+  });
+
+  test("小さい、大きい", () => {
+    expect(TransceiverUtil.analizeAmateurBandRange(-1)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(0)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(Number.MAX_SAFE_INTEGER)).toBe("");
+  });
+});

--- a/src/common/util/TransceiverUtil.ts
+++ b/src/common/util/TransceiverUtil.ts
@@ -1,9 +1,11 @@
+import CommonUtil from "@/common/CommonUtil";
+
 /**
  * 無線機関係のユーティリティ
  * @class TransceiverUtil
  * @typedef {TransceiverUtil}
  */
-class TransceiverUtil {
+export default class TransceiverUtil {
   /**
    * 周波数をMHzの数値からHzの数値に変換する
    * @param {number} mhz 周波数の数値[単位:MHz]
@@ -84,6 +86,31 @@ class TransceiverUtil {
     // IEEE754の丸め誤差を回避するため、小数点以下3桁で丸める
     return Math.round((freq1 - freq2) * 1000) / 1000;
   };
-}
 
-export default TransceiverUtil;
+  /**
+   * 指定の周波数がアマチュアバンドの範囲内かどうかを判定する
+   * @returns {string} アマチュアバンドの範囲外の場合は空文字を返す
+   */
+  public static analizeAmateurBandRange(freq: number): "144" | "430" | "1200" | "" {
+    if (!CommonUtil.isNumber(freq)) {
+      return "";
+    }
+
+    // 144MHz帯か？
+    if (144000000 <= freq && freq <= 146000000) {
+      return "144";
+    }
+
+    // 430MHz帯か？
+    if (432000000 <= freq && freq <= 440000000) {
+      return "430";
+    }
+
+    // 1200MHz帯か？
+    if (1294000000 <= freq && freq <= 1295000000) {
+      return "1200";
+    }
+
+    return "";
+  }
+}


### PR DESCRIPTION
#11 に付随する対応