### PR TITLE
無線機が未設定の場合はAuto On不可とする対応など

### DIFF
--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -151,6 +151,10 @@ export default class I18nMsgs {
     en: "An unexpected error has occurred",
     ja: "予期しないエラーが発生しました",
   };
+  public static readonly SYSTEM_YET_TRANSCEIVER_CONFIG: I18nMsgItem = {
+    en: "Transceiver is not set. Please set it in the Radio menu.",
+    ja: "無線機が未設定です。無線機メニューで設定を行ってください。",
+  };
   public static readonly SYSTEM_YET_ROTATOR_CONFIG: I18nMsgItem = {
     en: "Rotator is not set. Please set it in the rotator menu.",
     ja: "ローテータが未設定です。ローテータメニューで設定を行ってください。",

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -251,13 +251,16 @@ async function autoBtnClick() {
   loadingAutoBtn.value = true;
 
   // 現在のAuto状態を反転させて、Autoモードの開始/終了を要求する
-  autoStore.tranceiverAuto = !autoStore.tranceiverAuto;
-  if (autoStore.tranceiverAuto) {
+  const auto = !autoStore.tranceiverAuto;
+  if (auto) {
     // Autoモード開始
-    await startAutoMode();
+    const result = await startAutoMode();
+    // 開始の結果をストアに反映（開始できなかった場合はfalseが返ってくる）
+    autoStore.tranceiverAuto = result;
   } else {
     // Autoモード終了
     await stopAutoMode();
+    autoStore.tranceiverAuto = false;
   }
 
   loadingAutoBtn.value = false;

--- a/src/renderer/service/AntennaAutoTrackingService.ts
+++ b/src/renderer/service/AntennaAutoTrackingService.ts
@@ -32,15 +32,15 @@ export default class AntennaAutoTrackingService {
       return false;
     }
 
-    // 表示中の衛星グループが変更された場合のコールバックを設定
-    ActiveSatServiceHub.getInstance().addOnChangeActiveSat(this.onChangeActiveSat);
-
+    // ローテータが未設定の場合はトーストを表示して終了
     const rotDevice = await AppConfigUtil.getCurrentRotatorDevice();
     if (!rotDevice) {
-      // ローテータが未設定の場合
       emitter.emit(Constant.GlobalEvent.NOTICE_INFO, I18nUtil.getMsg(I18nMsgs.SYSTEM_YET_ROTATOR_CONFIG));
       return false;
     }
+
+    // 表示中の衛星グループが変更された場合のコールバックを設定
+    ActiveSatServiceHub.getInstance().addOnChangeActiveSat(this.onChangeActiveSat);
 
     const controller = await RotatorControllerFactory.getController(rotDevice);
 


### PR DESCRIPTION
- 無線機が未設定の場合はAuto On不可
- ローテータ未設定時にローテータのAutoクリック後（Onにならない状態で）、衛星設定画面にてOKをクリックすると落ちるバグ対応
　⇒ローテータのAntennaAutoTrackingServiceのインスタンスがない状態で、AntennaAutoTrackingService内のメソッドがコールバックされないようにした。