### PR TITLE
アマチュア無線の周波数帯の修正

### DIFF
--- a/src/__tests__/common/TransceiverUtil_analizeAmateurBandRange.test.ts
+++ b/src/__tests__/common/TransceiverUtil_analizeAmateurBandRange.test.ts
@@ -17,9 +17,9 @@ describe("TransceiverUtil.analizeAmateurBandRangeのテスト", () => {
   });
 
   test("430MHz帯", () => {
-    expect(TransceiverUtil.analizeAmateurBandRange(431999999)).toBe("");
-    expect(TransceiverUtil.analizeAmateurBandRange(432000000)).toBe("430");
-    expect(TransceiverUtil.analizeAmateurBandRange(432000001)).toBe("430");
+    expect(TransceiverUtil.analizeAmateurBandRange(429999999)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(430000000)).toBe("430");
+    expect(TransceiverUtil.analizeAmateurBandRange(430000001)).toBe("430");
 
     expect(TransceiverUtil.analizeAmateurBandRange(439999999)).toBe("430");
     expect(TransceiverUtil.analizeAmateurBandRange(440000000)).toBe("430");
@@ -27,13 +27,13 @@ describe("TransceiverUtil.analizeAmateurBandRangeのテスト", () => {
   });
 
   test("1.2GHz帯", () => {
-    expect(TransceiverUtil.analizeAmateurBandRange(1293999999)).toBe("");
-    expect(TransceiverUtil.analizeAmateurBandRange(1294000000)).toBe("1200");
-    expect(TransceiverUtil.analizeAmateurBandRange(1294000001)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1259999999)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(1260000000)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1260000001)).toBe("1200");
 
-    expect(TransceiverUtil.analizeAmateurBandRange(1294999999)).toBe("1200");
-    expect(TransceiverUtil.analizeAmateurBandRange(1295000000)).toBe("1200");
-    expect(TransceiverUtil.analizeAmateurBandRange(1295000001)).toBe("");
+    expect(TransceiverUtil.analizeAmateurBandRange(1299999999)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1300000000)).toBe("1200");
+    expect(TransceiverUtil.analizeAmateurBandRange(1300000001)).toBe("");
   });
 
   test("小さい、大きい", () => {

--- a/src/common/util/TransceiverUtil.ts
+++ b/src/common/util/TransceiverUtil.ts
@@ -102,12 +102,12 @@ export default class TransceiverUtil {
     }
 
     // 430MHz帯か？
-    if (432000000 <= freq && freq <= 440000000) {
+    if (430000000 <= freq && freq <= 440000000) {
       return "430";
     }
 
     // 1200MHz帯か？
-    if (1294000000 <= freq && freq <= 1295000000) {
+    if (1260000000 <= freq && freq <= 1300000000) {
       return "1200";
     }
 


### PR DESCRIPTION
#11 関連の修正
周波数の上限、下限に誤りがあったので修正。