### PR TITLE
周波数の単位をMhzからHzに変更

### DIFF
--- a/resources/data/init-data/default_satellite.json
+++ b/resources/data/init-data/default_satellite.json
@@ -6,22 +6,22 @@
         "satelliteName": "ISS (ZARYA)",
         "noradId": "25544",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ],

--- a/satellite_data/frequency.json
+++ b/satellite_data/frequency.json
@@ -1,12 +1,12 @@
 {
   "frequency": {
-    "lastUpdateTime": 1744146861765,
+    "lastUpdateTime": 1745146861765,
     "satellites": [
       {
         "noradId": "43017",
         "satelliteName": "RADFXSAT (FOX-1B) ",
         "uplink1": {
-          "uplinkHz": 435.25,
+          "uplinkHz": 435250000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -14,21 +14,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 145.96,
+          "downlinkHz": 145960000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "27607",
         "satelliteName": "SAUDISAT 1C (SO-50)",
         "uplink1": {
-          "uplinkHz": 145.85,
+          "uplinkHz": 1458500000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -36,21 +36,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 436.795,
+          "downlinkHz": 436795000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "43678",
         "satelliteName": "DIWATA-2B",
         "uplink1": {
-          "uplinkHz": 437.5,
+          "uplinkHz": 437500000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -58,21 +58,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 145.9,
+          "downlinkHz": 145900000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "40908",
         "satelliteName": "LILACSAT-2",
         "uplink1": {
-          "uplinkHz": 144.35,
+          "uplinkHz": 144350000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -80,21 +80,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 437.2,
+          "downlinkHz": 437200000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "40931",
         "satelliteName": "LAPAN-A2",
         "uplink1": {
-          "uplinkHz": 145.88,
+          "uplinkHz": 145880000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -102,21 +102,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 435.88,
+          "downlinkHz": 435880000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "25544",
         "satelliteName": "ISS (ZARYA)",
         "uplink1": {
-          "uplinkHz": 145.99,
+          "uplinkHz": 145990000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -124,21 +124,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 437.8,
+          "downlinkHz": 437800000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": "ISS Crossband Repeater"
       },
       {
         "noradId": "62690",
         "satelliteName": "HADES-R",
         "uplink1": {
-          "uplinkHz": 145.925,
+          "uplinkHz": 145925000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -146,21 +146,21 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 436.885,
+          "downlinkHz": 436885000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "61781",
         "satelliteName": "ASRTU-1 (AO-123)",
         "uplink1": {
-          "uplinkHz": 145.85,
+          "uplinkHz": 145850000,
           "uplinkMode": "FM"
         },
         "uplink2": {
@@ -168,36 +168,36 @@
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkHz": 435.4,
+          "downlinkHz": 435400000,
           "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       },
       {
         "noradId": "48274",
         "satelliteName": "CSS (TIANHE)",
         "uplink1": {
-          "uplinkHz": 145.875,
+          "uplinkHz": 145875000,
           "uplinkMode": "FM"
         },
         "uplink2": {
-          "uplinkHz": 435.075,
+          "uplinkHz": 435075000,
           "uplinkMode": "FM"
         },
         "downlink1": {
-          "downlinkHz": 436.51,
+          "downlinkHz": 436510000,
           "downlinkMode": "FM"
         },
         "downlink2": {
-          "downlinkHz": 145.985,
+          "downlinkHz": 145985000,
           "downlinkMode": "FM"
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ]

--- a/src/__tests__/common/TransceiverUtil.test.ts
+++ b/src/__tests__/common/TransceiverUtil.test.ts
@@ -22,4 +22,18 @@ describe("TransceiverUtil", () => {
     expect(TransceiverUtil.mhzToMhzString(1.5)).toBe("0001.500");
     expect(TransceiverUtil.mhzToMhzString(123.456)).toBe("0123.456");
   });
+
+  test("周波数をドット区切りの文字列に変換する", () => {
+    expect(TransceiverUtil.formatWithDot(1000000000)).toBe("1000.000.000");
+    expect(TransceiverUtil.formatWithDot(100000)).toBe("0000.100.000");
+    expect(TransceiverUtil.formatWithDot(100)).toBe("0000.000.100");
+    expect(TransceiverUtil.formatWithDot(1)).toBe("0000.000.001");
+  });
+
+  test("ドット区切りの文字列に数値の周波数に変換する", () => {
+    expect(TransceiverUtil.parseNumber("1000.000.000")).toBe(1000000000);
+    expect(TransceiverUtil.parseNumber("0000.100.000")).toBe(100000);
+    expect(TransceiverUtil.parseNumber("0000.000.100")).toBe(100);
+    expect(TransceiverUtil.parseNumber("0000.000.001")).toBe(1);
+  });
 });

--- a/src/__tests__/common/TransceiverUtil.test.ts
+++ b/src/__tests__/common/TransceiverUtil.test.ts
@@ -1,33 +1,13 @@
 import TransceiverUtil from "@/common/util/TransceiverUtil";
 
 describe("TransceiverUtil", () => {
-  test("周波数をMHzの数値からHzの数値に変換する", () => {
-    expect(TransceiverUtil.mhzToHz(1)).toBe(1000000);
-    expect(TransceiverUtil.mhzToHz(1.5)).toBe(1500000);
-  });
-
-  test("周波数をHzの数値からMHzの数値に変換する", () => {
-    expect(TransceiverUtil.hzToMhz(1000000)).toBe(1);
-    expect(TransceiverUtil.hzToMhz(1500000)).toBe(1.5);
-  });
-
-  test("周波数をHzの数値からMHzの文字列に変換する", () => {
-    expect(TransceiverUtil.hzToMhzString(1000000)).toBe("0001.000");
-    expect(TransceiverUtil.hzToMhzString(1500000)).toBe("0001.500");
-    expect(TransceiverUtil.hzToMhzString(123456789)).toBe("0123.456");
-  });
-
-  test("周波数をMHzの数値からMHzの文字列に変換する", () => {
-    expect(TransceiverUtil.mhzToMhzString(1.0)).toBe("0001.000");
-    expect(TransceiverUtil.mhzToMhzString(1.5)).toBe("0001.500");
-    expect(TransceiverUtil.mhzToMhzString(123.456)).toBe("0123.456");
-  });
-
   test("周波数をドット区切りの文字列に変換する", () => {
+    expect(TransceiverUtil.formatWithDot(11000000000)).toBe("1000.000.000");
     expect(TransceiverUtil.formatWithDot(1000000000)).toBe("1000.000.000");
     expect(TransceiverUtil.formatWithDot(100000)).toBe("0000.100.000");
     expect(TransceiverUtil.formatWithDot(100)).toBe("0000.000.100");
     expect(TransceiverUtil.formatWithDot(1)).toBe("0000.000.001");
+    expect(TransceiverUtil.formatWithDot(1.1)).toBe("0000.000.001");
   });
 
   test("ドット区切りの文字列に数値の周波数に変換する", () => {

--- a/src/__tests__/common/model/DefaultSatelliteModel.test.ts
+++ b/src/__tests__/common/model/DefaultSatelliteModel.test.ts
@@ -172,7 +172,7 @@ describe("DefaultSatelliteModel", () => {
       uplink2: { uplinkHz: null, uplinkMode: "" },
       downlink1: { downlinkHz: null, downlinkMode: "" },
       downlink2: { downlinkHz: null, downlinkMode: "" },
-      toneMhz: null,
+      toneHz: null,
       outline: "",
     };
     // Act

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh1/default_satellite.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh1/default_satellite.json
@@ -6,22 +6,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ],

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh1/frequency.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh1/frequency.json
@@ -7,22 +7,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ]

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/app_config.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/app_config.json
@@ -15,23 +15,23 @@
         "noradId": "43879",
         "autoModeUplinkFreq": 1,
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "autoModeDownlinkFreq": 1,
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": "",
         "visible": true
       }

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/default_satellite.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/default_satellite.json
@@ -6,22 +6,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ],

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/frequency.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh2/frequency.json
@@ -7,22 +7,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ]

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/app_config.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/app_config.json
@@ -15,23 +15,23 @@
         "noradId": "43879",
         "autoModeUplinkFreq": 1,
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "autoModeDownlinkFreq": 1,
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": "",
         "visible": true
       }

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/default_satellite.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/default_satellite.json
@@ -6,22 +6,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ],

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/frequency.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh3/frequency.json
@@ -7,22 +7,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ]

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh4/default_satellite.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh4/default_satellite.json
@@ -6,22 +6,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ],

--- a/src/__tests__/main/service/data_DefaultSatelliteService/refresh4/frequency.json
+++ b/src/__tests__/main/service/data_DefaultSatelliteService/refresh4/frequency.json
@@ -7,22 +7,22 @@
         "satelliteName": "ISAT",
         "noradId": "43879",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": ""
       }
     ]

--- a/src/__tests__/main/validator/AppConfigValidator_exec.test.ts
+++ b/src/__tests__/main/validator/AppConfigValidator_exec.test.ts
@@ -78,4 +78,22 @@ test("appVersion_num", () => {
   expect(results[0].errMsgItem).toBe(I18nMsgs.CHK_ERR_APPCONFIG_INVALID_ITEM);
 });
 
+/**
+ * 正常
+ * 衛星設定あり
+ */
+test("app_config", () => {
+  // テストデータ
+  const dataPath = path.resolve(__dirname, "data_AppConfigValidator_exec", "app_config.json");
+  const text = FileUtil.readText(dataPath);
+  const appConfig = JSON.parse(text);
+
+  // 実行
+  const validator = new AppConfigValidator();
+  const results = validator.exec(appConfig);
+
+  // 検証
+  expect(results.length).toBe(0);
+});
+
 // TODO: 設定ファイルは今後変動が予想されるため、確定後にその他のテストを記載する

--- a/src/__tests__/main/validator/FrequencyValidator_exec.test.ts
+++ b/src/__tests__/main/validator/FrequencyValidator_exec.test.ts
@@ -36,15 +36,15 @@ test("異常系：周波数が文字列", () => {
 
   // 検証
   expect(results.length).toBe(5);
-  expect(results[0].errItemName).toBe("frequency/satellites/0/uplink1/uplinkMhz");
+  expect(results[0].errItemName).toBe("frequency/satellites/0/uplink1/uplinkHz");
   expect(results[0].errMsgItem).toBe(I18nMsgs.CHK_ERR_FREQUENCY_INVALID_ITEM);
-  expect(results[1].errItemName).toBe("frequency/satellites/0/uplink2/uplinkMhz");
+  expect(results[1].errItemName).toBe("frequency/satellites/0/uplink2/uplinkHz");
   expect(results[1].errMsgItem).toBe(I18nMsgs.CHK_ERR_FREQUENCY_INVALID_ITEM);
-  expect(results[2].errItemName).toBe("frequency/satellites/0/downlink1/downlinkMhz");
+  expect(results[2].errItemName).toBe("frequency/satellites/0/downlink1/downlinkHz");
   expect(results[2].errMsgItem).toBe(I18nMsgs.CHK_ERR_FREQUENCY_INVALID_ITEM);
-  expect(results[3].errItemName).toBe("frequency/satellites/0/downlink2/downlinkMhz");
+  expect(results[3].errItemName).toBe("frequency/satellites/0/downlink2/downlinkHz");
   expect(results[3].errMsgItem).toBe(I18nMsgs.CHK_ERR_FREQUENCY_INVALID_ITEM);
-  expect(results[4].errItemName).toBe("frequency/satellites/0/toneMhz");
+  expect(results[4].errItemName).toBe("frequency/satellites/0/toneHz");
   expect(results[4].errMsgItem).toBe(I18nMsgs.CHK_ERR_FREQUENCY_INVALID_ITEM);
 });
 

--- a/src/__tests__/main/validator/data_AppConfigValidator_exec/app_config.json
+++ b/src/__tests__/main/validator/data_AppConfigValidator_exec/app_config.json
@@ -6,7 +6,35 @@
       "lastRetrievedDate": 0,
       "urls": []
     },
-    "satellites": [],
+    "satellites": [
+      {
+        "satelliteId": 230,
+        "userRegistered": false,
+        "userRegisteredSatelliteName": "1998-067XC",
+        "userRegisteredTle": "",
+        "noradId": "62296",
+        "autoModeUplinkFreq": 1,
+        "uplink1": {
+          "uplinkHz": 1000000000,
+          "uplinkMode": "LSB"
+        },
+        "uplink2": {
+          "uplinkHz": 1234567890,
+          "uplinkMode": "USB"
+        },
+        "autoModeDownlinkFreq": 1,
+        "downlink1": {
+          "downlinkHz": 1000000000,
+          "downlinkMode": "LSB"
+        },
+        "downlink2": {
+          "downlinkHz": 1234567890,
+          "downlinkMode": "FM"
+        },
+        "toneHz": 1000000000,
+        "outline": ""
+      }
+    ],
     "satelliteGroups": [],
     "satelliteSetting": {
       "satelliteChoiceMinEl": -1

--- a/src/__tests__/main/validator/data_FrequencyValidator_exec/frequency_is_string.json
+++ b/src/__tests__/main/validator/data_FrequencyValidator_exec/frequency_is_string.json
@@ -6,22 +6,22 @@
         "noradId": "20442",
         "satelliteName": "LUSAT (LO-19)",
         "uplink1": {
-          "uplinkMhz": "123.456",
+          "uplinkHz": "123.456",
           "uplinkMode": "LSB"
         },
         "uplink2": {
-          "uplinkMhz": "123.456",
+          "uplinkHz": "123.456",
           "uplinkMode": "LSB"
         },
         "downlink1": {
-          "downlinkMhz": "123.456",
+          "downlinkHz": "123.456",
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": "123.456",
+          "downlinkHz": "123.456",
           "downlinkMode": "FM"
         },
-        "toneMhz": "123.456",
+        "toneHz": "123.456",
         "outline": "周波数が文字列"
       }
     ]

--- a/src/__tests__/main/validator/data_FrequencyValidator_exec/frequency_or_mode.json
+++ b/src/__tests__/main/validator/data_FrequencyValidator_exec/frequency_or_mode.json
@@ -6,22 +6,22 @@
         "noradId": "20442",
         "satelliteName": "LUSAT (LO-19)",
         "uplink1": {
-          "uplinkMhz": 123.456,
+          "uplinkHz": 123.456,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": "LSB"
         },
         "downlink1": {
-          "downlinkMhz": 123.456,
+          "downlinkHz": 123.456,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": "LSB"
         },
-        "toneMhz": 123.456,
+        "toneHz": 123.456,
         "outline": "周波数かモード片方だけ設定"
       }
     ]

--- a/src/__tests__/main/validator/data_FrequencyValidator_exec/only_2.json
+++ b/src/__tests__/main/validator/data_FrequencyValidator_exec/only_2.json
@@ -6,22 +6,22 @@
         "noradId": "20442",
         "satelliteName": "LUSAT (LO-19)",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": 123.456,
+          "uplinkHz": 123.456,
           "uplinkMode": "LSB"
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": 123.456,
+          "downlinkHz": 123.456,
           "downlinkMode": "FM"
         },
-        "toneMhz": 123.456,
+        "toneHz": 123.456,
         "outline": "「2」だけ設定"
       }
     ]

--- a/src/__tests__/main/validator/data_FrequencyValidator_exec/success.json
+++ b/src/__tests__/main/validator/data_FrequencyValidator_exec/success.json
@@ -6,66 +6,66 @@
         "noradId": "07530",
         "satelliteName": "OSCAR 7 (AO-7)",
         "uplink1": {
-          "uplinkMhz": 123.456,
+          "uplinkHz": 123.456,
           "uplinkMode": "LSB"
         },
         "uplink2": {
-          "uplinkMhz": 123.456,
+          "uplinkHz": 123.456,
           "uplinkMode": "USB"
         },
         "downlink1": {
-          "downlinkMhz": 123.456,
+          "downlinkHz": 123.456,
           "downlinkMode": "CW"
         },
         "downlink2": {
-          "downlinkMhz": 123.456,
+          "downlinkHz": 123.456,
           "downlinkMode": "FM"
         },
-        "toneMhz": 123.456,
+        "toneHz": 123.456,
         "outline": "全部入力した例"
       },
       {
         "noradId": "14129",
         "satelliteName": "PHASE 3B (AO-10)",
         "uplink1": {
-          "uplinkMhz": 123.456,
+          "uplinkHz": 123.456,
           "uplinkMode": "AM"
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": 123.456,
+          "downlinkHz": 123.456,
           "downlinkMode": "AM"
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": "一部入力した例"
       },
       {
         "noradId": "14781",
         "satelliteName": "UOSAT 2 (UO-11)",
         "uplink1": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "uplink2": {
-          "uplinkMhz": null,
+          "uplinkHz": null,
           "uplinkMode": ""
         },
         "downlink1": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
         "downlink2": {
-          "downlinkMhz": null,
+          "downlinkHz": null,
           "downlinkMode": ""
         },
-        "toneMhz": null,
+        "toneHz": null,
         "outline": "入力しない例(入力がないならこのデータ自体も登録しなくて良い)"
       }
     ]

--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -14,6 +14,10 @@ export default class I18nMsgs {
     en: "Please enter a number greater than 0",
     ja: "0より大きい数字を入力してください",
   };
+  public static readonly CHK_ERR_POSITIVE_INT: I18nMsgItem = {
+    en: "Please enter a positive integer",
+    ja: "0より大きい整数を入力してください",
+  };
   public static readonly CHK_ERR_NUM_DECIMAL: I18nMsgItem = {
     en: "Please enter a maximum of {0} decimal places",
     ja: "最大{0}桁の小数で入力してください",

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -85,7 +85,7 @@ export class AppConfigSatellite {
   // 対象衛星ダウンリンク設定2
   public downlink2 = new Downlink();
   // トーン周波数
-  public toneMhz: number | null = null;
+  public toneHz: number | null = null;
   // 対象衛星概要
   public outline = "";
 }
@@ -94,7 +94,7 @@ export class AppConfigSatellite {
  * アップリンク設定タイプ
  */
 export class Uplink {
-  // アップリンク周波数(Mhz)
+  // アップリンク周波数(Hz)
   public uplinkHz: number | null = null;
   // アップリンクモード
   public uplinkMode = "";
@@ -104,7 +104,7 @@ export class Uplink {
  * ダウンリンク設定タイプ
  */
 export class Downlink {
-  // ダウンリンク周波数(Mhz)
+  // ダウンリンク周波数(Hz)
   public downlinkHz: number | null = null;
   // ダウンリンクモード
   public downlinkMode = "";

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -151,9 +151,9 @@ export class AppConfigTransceiver {
   // 自動周波数制御インターバル（秒）
   public autoTrackingIntervalSec = "1";
   // 無線機の送信周波数
-  public txFrequency = "2430.000";
+  public txFrequency = "2430.000.000";
   // 無線機の受信周波数
-  public rxFrequency = "0480.000";
+  public rxFrequency = "0480.000.000";
 }
 
 /**

--- a/src/common/model/DefaultSatelliteModel.ts
+++ b/src/common/model/DefaultSatelliteModel.ts
@@ -116,7 +116,7 @@ export class DefaultSatelliteModel {
       uplink2: { uplinkHz: null, uplinkMode: "" },
       downlink1: { downlinkHz: null, downlinkMode: "" },
       downlink2: { downlinkHz: null, downlinkMode: "" },
-      toneMhz: null,
+      toneHz: null,
       outline: "",
     };
 

--- a/src/common/types/satelliteSettingTypes.ts
+++ b/src/common/types/satelliteSettingTypes.ts
@@ -53,7 +53,7 @@ export type DefaultSatelliteType = {
   // 対象衛星ダウンリンク設定2
   downlink2: DownlinkType;
   // トーン周波数
-  toneMhz: number | null;
+  toneHz: number | null;
   // 対象衛星概要
   outline: string;
 };

--- a/src/common/util/TransceiverUtil.ts
+++ b/src/common/util/TransceiverUtil.ts
@@ -7,56 +7,15 @@ import CommonUtil from "@/common/CommonUtil";
  */
 export default class TransceiverUtil {
   /**
-   * 周波数をMHzの数値からHzの数値に変換する
-   * @param {number} mhz 周波数の数値[単位:MHz]
-   * @returns {number} 周波数の数値[単位:Hz]
-   */
-  public static mhzToHz = (mhz: number): number => {
-    return Math.floor(mhz * 1000000);
-  };
-
-  /**
-   * 周波数をHzの数値からMHzの数値に変換する
-   * @param {number} hz 周波数の数値[単位:Hz]
-   * @returns {number} 周波数の数値[単位:MHz]
-   */
-  public static hzToMhz = (hz: number): number => {
-    return Math.floor(hz / 1000) / 1000;
-  };
-
-  /**
-   * 周波数のkHz未満を切り捨てる
-   * @param {number} mhz 周波数の数値[単位:MHz]
-   * @returns {number} 周波数の数値[単位MHz]
-   */
-  public static floorMhz = (mhz: number): number => {
-    return Math.floor(mhz * 1000) / 1000;
-  };
-
-  /**
-   * 周波数をHzの数値からMHzの文字列に変換する
-   * @param {number} hz 周波数の数値[単位:Hz]
-   * @returns {string} 周波数の文字列[単位:MHz]
-   */
-  public static hzToMhzString(hz: number): string {
-    // 小数点以下3桁にフォーマット
-    const mhzStr = this.hzToMhz(hz).toFixed(3);
-    // 整数部と小数部に分割
-    const [integerPart, decimalPart] = mhzStr.split(".");
-    // 整数部を4桁にパディング
-    const paddedIntegerPart = integerPart.padStart(4, "0");
-    // 整数部と小数部を結合して8文字にする
-    return `${paddedIntegerPart}.${decimalPart}`;
-  }
-
-  /**
    * 数値　→ ドット区切り文字列
    * @param hz
    * @returns
    */
   public static formatWithDot(hz: number): string {
     // 10桁にパディング
-    const padHz = hz.toString().padStart(10, "0");
+    // 整数として扱う
+    // 10桁以上の場合は、下10桁を取得
+    const padHz = Math.floor(hz).toString().slice(-10).padStart(10, "0");
 
     // 各桁を取得
     const digitMHz = padHz.slice(0, 4);
@@ -78,26 +37,10 @@ export default class TransceiverUtil {
   }
 
   /**
-   * 周波数をMHzの数値からMHzの文字列に変換する
-   * @param {number} mhz 周波数の数値[単位:MHz]
-   * @returns {string} 周波数の文字列[単位:MHz]
-   */
-  public static mhzToMhzString(mhz: number): string {
-    // 小数点以下3桁にフォーマット
-    const mhzStr = this.floorMhz(mhz).toFixed(3);
-    // 整数部と小数部に分割
-    const [integerPart, decimalPart] = mhzStr.split(".");
-    // 整数部を4桁にパディング
-    const paddedIntegerPart = integerPart.padStart(4, "0");
-    // 整数部と小数部を結合して8文字にする
-    return `${paddedIntegerPart}.${decimalPart}`;
-  }
-
-  /**
    * 2つの周波数を足し算する
-   * @param {number} freq1 周波数1[単位:MHz]
-   * @param {number} freq2 周波数2[単位:MHz]
-   * @returns {number} 演算結果[単位:MHz]
+   * @param {number} freq1 周波数1[単位:Hz]
+   * @param {number} freq2 周波数2[単位:Hz]
+   * @returns {number} 演算結果[単位:Hz]
    */
   public static addFrequencies = (freq1: number, freq2: number): number => {
     // IEEE754の丸め誤差を回避するため、小数点以下3桁で丸める
@@ -106,9 +49,9 @@ export default class TransceiverUtil {
 
   /**
    * 2つの周波数を引き算する
-   * @param {number} freq1 周波数1[単位:MHz]
-   * @param {number} freq2 周波数2[単位:MHz]
-   * @returns {number} 演算結果[単位:MHz]
+   * @param {number} freq1 周波数1[単位:Hz]
+   * @param {number} freq2 周波数2[単位:Hz]
+   * @returns {number} 演算結果[単位:Hz]
    */
   public static subtractFrequencies = (freq1: number, freq2: number): number => {
     // IEEE754の丸め誤差を回避するため、小数点以下3桁で丸める

--- a/src/common/util/TransceiverUtil.ts
+++ b/src/common/util/TransceiverUtil.ts
@@ -50,6 +50,34 @@ export default class TransceiverUtil {
   }
 
   /**
+   * 数値　→ ドット区切り文字列
+   * @param hz
+   * @returns
+   */
+  public static formatWithDot(hz: number): string {
+    // 10桁にパディング
+    const padHz = hz.toString().padStart(10, "0");
+
+    // 各桁を取得
+    const digitMHz = padHz.slice(0, 4);
+    const digitKHz = padHz.slice(4, 7);
+    const digitHz = padHz.slice(7, 10);
+
+    // ドット区切りの文字列に変換
+    return `${digitMHz}.${digitKHz}.${digitHz}`;
+  }
+
+  /**
+   * ドット区切り文字列 → 数値
+   * @param value
+   */
+  public static parseNumber(value: string): number {
+    const numeric = value.replace(/\./g, "");
+    const parsed = parseFloat(numeric);
+    return isNaN(parsed) ? 0 : parsed;
+  }
+
+  /**
    * 周波数をMHzの数値からMHzの文字列に変換する
    * @param {number} mhz 周波数の数値[単位:MHz]
    * @returns {string} 周波数の文字列[単位:MHz]

--- a/src/main/validator/AppConfigValidator.ts
+++ b/src/main/validator/AppConfigValidator.ts
@@ -101,7 +101,7 @@ const schemaSatellite = zod.object({
   // 対象衛星ダウンリンク設定2
   downlink2: schemaDownlink,
   // 対象衛星トーン周波数（Mhz）
-  toneMhz: zod.number().nullable(),
+  toneHz: zod.number().nullable(),
   // 対象衛星概要
   outline: zod.string(),
 });

--- a/src/main/validator/AppConfigValidator.ts
+++ b/src/main/validator/AppConfigValidator.ts
@@ -100,7 +100,7 @@ const schemaSatellite = zod.object({
   downlink1: schemaDownlink,
   // 対象衛星ダウンリンク設定2
   downlink2: schemaDownlink,
-  // 対象衛星トーン周波数（Mhz）
+  // 対象衛星トーン周波数（Hz）
   toneHz: zod.number().nullable(),
   // 対象衛星概要
   outline: zod.string(),

--- a/src/main/validator/FrequencyValidator.ts
+++ b/src/main/validator/FrequencyValidator.ts
@@ -92,7 +92,7 @@ export default class FrequencyValidator {
  * zodスキーマ定義 Uplink
  */
 const schemaUplink = zod.object({
-  // アップリンク周波数（Mhz）
+  // アップリンク周波数（Hz）
   uplinkHz: zod.number().nullable(),
   // アップリンクモード
   uplinkMode: zod.string(),
@@ -102,7 +102,7 @@ const schemaUplink = zod.object({
  * zodスキーマ定義 Downlink
  */
 const schemaDownlink = zod.object({
-  // ダウンリンク周波数（Mhz）
+  // ダウンリンク周波数（Hz）
   downlinkHz: zod.number().nullable(),
   // ダウンリンクモード
   downlinkMode: zod.string(),
@@ -124,8 +124,8 @@ const schemaSatellite = zod.object({
   downlink1: schemaDownlink,
   // 衛星ダウンリンク設定2
   downlink2: schemaDownlink,
-  // 衛星トーン周波数（Mhz）
-  toneMhz: zod.number().nullable(),
+  // 衛星トーン周波数（Hz）
+  toneHz: zod.number().nullable(),
   // 衛星概要
   outline: zod.string(),
 });

--- a/src/renderer/components/atoms/DigitTextField/DigitTextField.vue
+++ b/src/renderer/components/atoms/DigitTextField/DigitTextField.vue
@@ -62,20 +62,29 @@ watch(
 watch(displayValue, (newVal) => {
   model.value = parseNumber(newVal);
 });
-// 数値 → カンマ付き文字列
+
+/**
+ * 数値 → カンマ付き文字列
+ * @param value
+ */
 function formatNumber(value: number): string {
   if (!value) return "";
   return value.toLocaleString();
 }
 
-// カンマ付き文字列 → 数値（数値でない場合は 0 にフォールバック）
+/**
+ * カンマ付き文字列 → 数値（数値でない場合は null にフォールバック）
+ * @param value
+ */
 function parseNumber(value: string): number | null {
   const numeric = value.replace(/,/g, "");
   const parsed = parseFloat(numeric);
   return isNaN(parsed) ? null : parsed;
 }
 
-// カンマ付きで表示
+/**
+ * カンマ付きで表示
+ */
 function formatWithComma() {
   displayValue.value = formatNumber(model.value);
 }

--- a/src/renderer/components/atoms/DigitTextField/DigitTextField.vue
+++ b/src/renderer/components/atoms/DigitTextField/DigitTextField.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-text-field
+    v-model="displayValue"
+    variant="outlined"
+    hide-details
+    :error="!CommonUtil.isEmpty(errorText)"
+    class="textfield"
+    @blur="onInput(model)"
+  >
+    <ValidateTooltip :target="errorText" />
+  </v-text-field>
+</template>
+
+<script setup lang="ts">
+import CommonUtil from "@/common/CommonUtil";
+import { useValidate } from "@/renderer/common/hook/useValidate";
+import ValidateTooltip from "@/renderer/components/atoms/ValidateTooltip/ValidateTooltip.vue";
+import { onMounted, ref, watch } from "vue";
+
+const model = defineModel<any>();
+const errorText = defineModel<string>("errorText", { required: false, default: "" });
+// 表示用の文字列（カンマ区切り）
+const displayValue = ref<string>("");
+
+const props = defineProps({
+  valiSchema: {
+    type: Object, // as () => ZodObject<any>,
+    required: false,
+    default: null,
+  },
+  valiSchemaFieldPath: {
+    type: String,
+    required: false,
+    default: "",
+  },
+});
+
+const { validateAt } = useValidate(props.valiSchema);
+
+onMounted(() => {
+  // エラーメッセージをクリア
+  errorText.value = "";
+});
+
+/**
+ * 入力イベントのハンドラ
+ */
+async function onInput(val: string) {
+  errorText.value = await validateAt(props.valiSchemaFieldPath, val);
+  formatWithComma();
+}
+// model → displayValue への変換
+watch(
+  model,
+  (newVal) => {
+    displayValue.value = formatNumber(newVal);
+  },
+  { immediate: true }
+);
+
+// displayValue → model への変換
+watch(displayValue, (newVal) => {
+  model.value = parseNumber(newVal);
+});
+// 数値 → カンマ付き文字列
+function formatNumber(value: number): string {
+  if (!value) return "";
+  return value.toLocaleString();
+}
+
+// カンマ付き文字列 → 数値（数値でない場合は 0 にフォールバック）
+function parseNumber(value: string): number | null {
+  const numeric = value.replace(/,/g, "");
+  const parsed = parseFloat(numeric);
+  return isNaN(parsed) ? null : parsed;
+}
+
+// カンマ付きで表示
+function formatWithComma() {
+  displayValue.value = formatNumber(model.value);
+}
+</script>
+<style module lang="scss" scoped></style>

--- a/src/renderer/components/molecules/FrequencySelect/FrequencySelect.vue
+++ b/src/renderer/components/molecules/FrequencySelect/FrequencySelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="freq_box">
     <span
-      v-for="(digit, index) in digits"
+      v-for="(digit, index) in mHzDigits"
       :key="index"
       @wheel.passive="(event) => handleWheel(event, index)"
       @contextmenu.prevent="() => handleRightClick(index)"
@@ -14,18 +14,35 @@
     </span>
     <span class="decimal_point">.</span>
     <span
-      v-for="(digit, index) in decimalDigits"
-      :key="index + digits.length"
-      @wheel.passive="(event) => handleWheel(event, index + digits.length)"
-      @contextmenu.prevent="() => handleRightClick(index + digits.length)"
-      @click="handleClick(index + digits.length)"
-      @mouseover="hoverIndex = index + digits.length"
+      v-for="(digit, index) in kHzDigits"
+      :key="index + mHzDigits.length"
+      @wheel.passive="(event) => handleWheel(event, index + mHzDigits.length)"
+      @contextmenu.prevent="() => handleRightClick(index + mHzDigits.length)"
+      @click="handleClick(index + mHzDigits.length)"
+      @mouseover="hoverIndex = index + mHzDigits.length"
       @mouseleave="hoverIndex = null"
-      :class="{ hovered: hoverIndex === index + digits.length, grayed: isGrayed(index + digits.length) }"
+      :class="{ hovered: hoverIndex === index + mHzDigits.length, grayed: isGrayed(index + mHzDigits.length) }"
     >
       {{ digit }}
     </span>
-    <span class="freq_unit">MHz</span>
+    <span class="decimal_point">.</span>
+    <span
+      v-for="(digit, index) in hzDigits"
+      :key="index + mHzDigits.length + kHzDigits.length"
+      @wheel.passive="(event) => handleWheel(event, index + mHzDigits.length + kHzDigits.length)"
+      @contextmenu.prevent="() => handleRightClick(index + mHzDigits.length + kHzDigits.length)"
+      @click="handleClick(index + mHzDigits.length + kHzDigits.length)"
+      @mouseover="hoverIndex = index + mHzDigits.length + kHzDigits.length"
+      @mouseleave="hoverIndex = null"
+      :class="{
+        hovered: hoverIndex === index + mHzDigits.length + kHzDigits.length,
+        grayed: isGrayed(index + mHzDigits.length + kHzDigits.length),
+      }"
+    >
+      {{ digit }}
+    </span>
+
+    <span class="freq_unit">Hz</span>
   </div>
 </template>
 
@@ -39,7 +56,8 @@ const frequency = defineModel<string>("frequency", { required: true });
 const diffFrequency = defineModel<number>("diffFrequency", { required: true });
 
 // フック
-const { digits, decimalDigits, hoverIndex, onWheel, onRightClick, onClick, isGrayed } = useFrequencySelect(frequency);
+const { mHzDigits, kHzDigits, hzDigits, hoverIndex, onWheel, onRightClick, onClick, isGrayed } =
+  useFrequencySelect(frequency);
 
 // ホイールイベントの処理
 function handleWheel(event: WheelEvent, index: number) {

--- a/src/renderer/components/molecules/FrequencySelect/useFrequencySelect.ts
+++ b/src/renderer/components/molecules/FrequencySelect/useFrequencySelect.ts
@@ -6,8 +6,8 @@ import { computed, ref, type Ref } from "vue";
  * @returns {*} 周波数コントローラー
  */
 const useFrequencySelect = (frequency: Ref<string>) => {
-  // 整数部分の桁を計算する
-  const digits = computed(() =>
+  // MHzの桁を計算する
+  const mHzDigits = computed(() =>
     frequency.value
       .split(".")[0]
       .split("")
@@ -17,10 +17,21 @@ const useFrequencySelect = (frequency: Ref<string>) => {
       })
   );
 
-  // 小数部分の桁を計算する
-  const decimalDigits = computed(() =>
+  // kHzの桁を計算する
+  const kHzDigits = computed(() =>
     frequency.value
       .split(".")[1]
+      .split("")
+      .map((char) => {
+        const digit = Number(char);
+        return isNaN(digit) ? 0 : digit;
+      })
+  );
+
+  // Hzの桁を計算する
+  const hzDigits = computed(() =>
+    frequency.value
+      .split(".")[2]
       .split("")
       .map((char) => {
         const digit = Number(char);
@@ -33,7 +44,7 @@ const useFrequencySelect = (frequency: Ref<string>) => {
 
   // ホイールイベントの処理
   function onWheel(event: WheelEvent, index: number) {
-    const newDigits = [...digits.value, ...decimalDigits.value];
+    const newDigits = [...mHzDigits.value, ...kHzDigits.value, ...hzDigits.value];
     if (event.deltaY < 0) {
       // ホイールを上に回した場合
       newDigits[index] = (newDigits[index] + 1) % 10;
@@ -66,14 +77,24 @@ const useFrequencySelect = (frequency: Ref<string>) => {
       // 全ての桁が0となる場合は終了する
       return null;
     }
-    return newDigits.slice(0, digits.value.length).join("") + "." + newDigits.slice(digits.value.length).join("");
+    // 数値の配列をカンマ区切りの文字列にする
+    const mHzIndex = mHzDigits.value.length;
+    const kHzIndex = mHzIndex + kHzDigits.value.length;
+    const hzIndex = kHzIndex + hzDigits.value.length;
+    return (
+      newDigits.slice(0, mHzIndex).join("") +
+      "." +
+      newDigits.slice(mHzIndex, kHzIndex).join("") +
+      "." +
+      newDigits.slice(kHzIndex, hzIndex).join("")
+    );
   }
 
   // 右クリックイベントの処理
   function onRightClick(index: number) {
     // 最大桁の場合は終了する
     if (index === 0) return null;
-    const newDigits = [...digits.value, ...decimalDigits.value];
+    const newDigits = [...mHzDigits.value, ...kHzDigits.value, ...hzDigits.value];
     if (newDigits.slice(0, index).every((digit) => digit === 0)) {
       // 全て0となる場合は終了する
       return null;
@@ -83,12 +104,22 @@ const useFrequencySelect = (frequency: Ref<string>) => {
     for (let i = index; i < newDigits.length; i++) {
       newDigits[i] = 0;
     }
-    return newDigits.slice(0, digits.value.length).join("") + "." + newDigits.slice(digits.value.length).join("");
+    // 数値の配列をカンマ区切りの文字列にする
+    const mHzIndex = mHzDigits.value.length;
+    const kHzIndex = mHzIndex + kHzDigits.value.length;
+    const hzIndex = kHzIndex + hzDigits.value.length;
+    return (
+      newDigits.slice(0, mHzIndex).join("") +
+      "." +
+      newDigits.slice(mHzIndex, kHzIndex).join("") +
+      "." +
+      newDigits.slice(kHzIndex, hzIndex).join("")
+    );
   }
 
   // 左クリックイベントの処理
   function onClick(index: number) {
-    const newDigits = [...digits.value, ...decimalDigits.value];
+    const newDigits = [...mHzDigits.value, ...kHzDigits.value, ...hzDigits.value];
     // 左クリックされた桁を+1する
     newDigits[index] = (newDigits[index] + 1) % 10;
     for (let i = index; i > 0; i--) {
@@ -98,19 +129,30 @@ const useFrequencySelect = (frequency: Ref<string>) => {
         break;
       }
     }
-    return newDigits.slice(0, digits.value.length).join("") + "." + newDigits.slice(digits.value.length).join("");
+    // 数値の配列をカンマ区切りの文字列にする
+    const mHzIndex = mHzDigits.value.length;
+    const kHzIndex = mHzIndex + kHzDigits.value.length;
+    const hzIndex = kHzIndex + hzDigits.value.length;
+    return (
+      newDigits.slice(0, mHzIndex).join("") +
+      "." +
+      newDigits.slice(mHzIndex, kHzIndex).join("") +
+      "." +
+      newDigits.slice(kHzIndex, hzIndex).join("")
+    );
   }
 
   // 先頭の0の桁をグレーアウトする
   function isGrayed(index: number) {
-    const newDigits = [...digits.value, ...decimalDigits.value];
+    const newDigits = [...mHzDigits.value, ...kHzDigits.value, ...hzDigits.value];
     const firstNonZeroIndex = newDigits.findIndex((digit) => digit !== 0);
     return index < firstNonZeroIndex;
   }
 
   return {
-    digits,
-    decimalDigits,
+    mHzDigits,
+    kHzDigits,
+    hzDigits,
     hoverIndex,
     onWheel,
     onRightClick,

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
@@ -33,7 +33,7 @@
   th,
   td {
     border: none;
-    padding: 2px 3px 2px 3px;
+    padding: 3px 3px 3px 3px;
     text-align: center;
     font-size: 0.8rem;
   }
@@ -64,7 +64,7 @@
 
 // Modeボタン
 .mode_btn {
-  width: 90px;
+  width: 100px;
   margin: 5px;
   height: 30px;
 }
@@ -81,7 +81,7 @@
 
 // Satelliteボタン
 .sat_btn {
-  width: 190px;
+  width: 210px;
   margin: 5px;
   height: 30px;
 }

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -14,19 +14,19 @@
       <div class="freq_area">
         <div>
           Tx<FrequencySelect class="freq_box" v-model:frequency="txFrequency" v-model:diffFrequency="diffTxFrequency"
-            ><span class="freq_unit">MHz</span></FrequencySelect
+            ><span class="freq_unit">Hz</span></FrequencySelect
           >
         </div>
       </div>
       <div class="freq_area">
         <div v-if="isSatelliteMode">
           Rx<FrequencySelect class="freq_box" v-model:frequency="rxFrequency" v-model:diffFrequency="diffRxFrequency"
-            ><span class="freq_unit">MHz</span></FrequencySelect
+            ><span class="freq_unit">Hz</span></FrequencySelect
           >
         </div>
         <div v-else>
           Rx<FrequencySelect class="freq_box" v-model:frequency="txFrequency" v-model:diffFrequency="diffRxFrequency"
-            ><span class="freq_unit">MHz</span></FrequencySelect
+            ><span class="freq_unit">Hz</span></FrequencySelect
           >
         </div>
       </div>

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -309,7 +309,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   // アップリンク周波数が変更された場合にAPIを呼び出す
   watch(txFrequency, async (newFrequency) => {
     // アップリンク周波数を更新する
-    await updateTxFrequency(Number(newFrequency));
+    await updateTxFrequency(TransceiverUtil.parseNumber(newFrequency));
   });
 
   // 画面でアップリンク周波数が変更された場合に変化量を反映する
@@ -346,7 +346,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     }
 
     // ダウンリンク周波数を更新する
-    await updateRxFrequency(Number(newFrequency));
+    await updateRxFrequency(TransceiverUtil.parseNumber(newFrequency));
   });
 
   // 画面でダウンリンク周波数が変更された場合に変化量を反映する

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -105,8 +105,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
     // Auto開始をメイン側に連携する
     await ApiTransceiver.initAutoOn(
-      TransceiverUtil.mhzToHz(parseInt(txFrequency.value)),
-      TransceiverUtil.mhzToHz(parseInt(rxFrequency.value))
+      TransceiverUtil.parseNumber(txFrequency.value),
+      TransceiverUtil.parseNumber(rxFrequency.value)
     );
 
     // ドップラーシフトの基準周波数を設定する

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -19,9 +19,9 @@ import { onMounted, ref, Ref, watch } from "vue";
  */
 const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   // アップリンク周波数
-  const txFrequency = ref<string>("2430.000");
+  const txFrequency = ref<string>("2430.000.000");
   // ダウンリンク周波数
-  const rxFrequency = ref<string>("0480.000");
+  const rxFrequency = ref<string>("0480.000.000");
   // アップリンク周波数の変化量
   const diffTxFrequency = ref<number>(0.0);
   // ダウンリンク周波数の変化量
@@ -88,7 +88,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const transceiverSetting = await ActiveSatServiceHub.getInstance().getActiveSatTransceiverSetting();
     if (transceiverSetting.uplink && transceiverSetting.uplink.uplinkHz) {
       // アップリンク周波数/運用モードをアクティブ衛星の設定で更新する
-      txFrequency.value = TransceiverUtil.hzToMhzString(transceiverSetting.uplink.uplinkHz);
+      txFrequency.value = TransceiverUtil.formatWithDot(transceiverSetting.uplink.uplinkHz);
       txOpeMode.value = transceiverSetting.uplink.uplinkMode;
 
       // 運用モードによってUSB/LSBモード判定、AM/FMモード判定を更新する
@@ -96,7 +96,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     }
     if (transceiverSetting.downlink && transceiverSetting.downlink.downlinkHz) {
       // ダウンリンク周波数/運用モードをアクティブ衛星の設定で更新する
-      rxFrequency.value = TransceiverUtil.hzToMhzString(transceiverSetting.downlink.downlinkHz);
+      rxFrequency.value = TransceiverUtil.formatWithDot(transceiverSetting.downlink.downlinkHz);
       rxOpeMode.value = transceiverSetting.downlink.downlinkMode;
 
       // 運用モードによってUSB/LSBモード判定、AM/FMモード判定を更新する
@@ -110,8 +110,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     );
 
     // ドップラーシフトの基準周波数を設定する
-    dopplerTxBaseFrequency.value = Number(txFrequency.value);
-    dopplerRxBaseFrequency.value = Number(rxFrequency.value);
+    dopplerTxBaseFrequency.value = TransceiverUtil.parseNumber(txFrequency.value);
+    dopplerRxBaseFrequency.value = TransceiverUtil.parseNumber(rxFrequency.value);
 
     // 周波数の更新インターバルを取得
     autoTrackingIntervalMsec = parseFloat(appConfig.transceiver.autoTrackingIntervalSec) * 1000;
@@ -211,7 +211,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
    */
   async function updateTxFrequency(newTxFrequency: number) {
     await ApiTransceiver.setTransceiverFrequency({
-      uplinkHz: TransceiverUtil.mhzToHz(newTxFrequency),
+      uplinkHz: newTxFrequency,
       uplinkMode: "",
     });
   }
@@ -222,7 +222,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
    */
   async function updateRxFrequency(newRxFrequency: number) {
     await ApiTransceiver.setTransceiverFrequency({
-      downlinkHz: TransceiverUtil.mhzToHz(newRxFrequency),
+      downlinkHz: newRxFrequency,
       downlinkMode: "",
     });
   }
@@ -242,7 +242,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     // 無線機のアップリンク周波数を更新する
     await updateTxFrequency(dopplerTxBaseFrequency.value * txDopplerFactor);
     // 画面のアップリンク周波数を更新する
-    txFrequency.value = TransceiverUtil.mhzToMhzString(dopplerTxBaseFrequency.value * txDopplerFactor);
+    txFrequency.value = TransceiverUtil.formatWithDot(dopplerTxBaseFrequency.value * txDopplerFactor);
     // AppMainLogger.debug(
     //   "ドップラーシフト補正値(Tx): " +
     //     TransceiverUtil.subtractFrequencies(
@@ -268,7 +268,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     // 無線機のダウンリンク周波数を更新する
     await updateRxFrequency(dopplerRxBaseFrequency.value * rxDopplerFactor);
     // 画面のダウンリンク周波数を更新する
-    rxFrequency.value = TransceiverUtil.mhzToMhzString(dopplerRxBaseFrequency.value * rxDopplerFactor);
+    rxFrequency.value = TransceiverUtil.formatWithDot(dopplerRxBaseFrequency.value * rxDopplerFactor);
     // AppMainLogger.debug(
     //   "ドップラーシフト補正値(Rx): " +
     //     TransceiverUtil.subtractFrequencies(
@@ -370,8 +370,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
     if (isSatTrackingModeNormal.value) {
       // トラッキングモードがNORMALの場合、アップリンク周波数とダウンリンク周波数の変化量を同一方向に同じステップで変化させる
-      txFrequency.value = TransceiverUtil.mhzToMhzString(
-        TransceiverUtil.subtractFrequencies(Number(txFrequency.value), diffRxFrequency.value)
+      txFrequency.value = TransceiverUtil.formatWithDot(
+        TransceiverUtil.subtractFrequencies(TransceiverUtil.parseNumber(txFrequency.value), diffRxFrequency.value)
       );
       // ドップラーシフトの基準周波数に画面で操作した変化量を反映する
       dopplerTxBaseFrequency.value = TransceiverUtil.subtractFrequencies(
@@ -380,8 +380,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       );
     } else {
       // トラッキングモードがREVERSEの場合、アップリンク周波数とダウンリンク周波数の変化量を逆方向に同じステップで変化させる
-      txFrequency.value = TransceiverUtil.mhzToMhzString(
-        TransceiverUtil.addFrequencies(Number(txFrequency.value), diffRxFrequency.value)
+      txFrequency.value = TransceiverUtil.formatWithDot(
+        TransceiverUtil.addFrequencies(TransceiverUtil.parseNumber(txFrequency.value), diffRxFrequency.value)
       );
       // ドップラーシフトの基準周波数に画面で操作した変化量を反映する
       dopplerTxBaseFrequency.value = TransceiverUtil.addFrequencies(
@@ -459,14 +459,14 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
       if ("uplinkHz" in frequency && frequency.uplinkHz) {
         // アップリンク周波数を更新する
-        txFrequency.value = TransceiverUtil.hzToMhzString(frequency.uplinkHz);
+        txFrequency.value = TransceiverUtil.formatWithDot(frequency.uplinkHz);
         // ドップラーシフトの基準周波数を更新する
-        dopplerTxBaseFrequency.value = TransceiverUtil.hzToMhz(frequency.uplinkHz);
+        dopplerTxBaseFrequency.value = frequency.uplinkHz;
       } else if ("downlinkHz" in frequency && frequency.downlinkHz) {
         // ダウンリンク周波数を更新する
-        rxFrequency.value = TransceiverUtil.hzToMhzString(frequency.downlinkHz);
+        rxFrequency.value = TransceiverUtil.formatWithDot(frequency.downlinkHz);
         // ドップラーシフトの基準周波数を更新する
-        dopplerRxBaseFrequency.value = TransceiverUtil.hzToMhz(frequency.downlinkHz);
+        dopplerRxBaseFrequency.value = frequency.downlinkHz;
       }
     });
 

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -60,7 +60,7 @@
             <label class="label form__label">{{ I18nUtil.getMsg(I18nMsgs.G31_UPLINK) }}</label>
           </v-col>
           <v-col cols="4">
-            <TextField
+            <DigitTextField
               v-model="form.uplink1Hz"
               suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
@@ -75,7 +75,7 @@
           ></v-col>
           <v-col cols="4"> </v-col>
           <v-col cols="4">
-            <TextField
+            <DigitTextField
               v-model="form.uplink2Hz"
               suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
@@ -98,7 +98,7 @@
             <label class="label form__label">{{ I18nUtil.getMsg(I18nMsgs.G31_DOWNLINK) }}</label>
           </v-col>
           <v-col cols="4">
-            <TextField
+            <DigitTextField
               v-model="form.downlink1Hz"
               suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
@@ -113,7 +113,7 @@
           ></v-col>
           <v-col cols="4"> </v-col>
           <v-col cols="4">
-            <TextField
+            <DigitTextField
               v-model="form.downlink2Hz"
               suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
@@ -136,7 +136,7 @@
             <label class="label form__label">{{ I18nUtil.getMsg(I18nMsgs.G31_TONE) }}</label>
           </v-col>
           <v-col cols="4">
-            <TextField
+            <DigitTextField
               v-model="form.toneHz"
               suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
@@ -183,6 +183,7 @@ import ApiAppConfig from "@/renderer/api/ApiAppConfig";
 import ApiAppConfigSatellite from "@/renderer/api/ApiAppConfigSatellite";
 import ApiDefaultSatellite from "@/renderer/api/ApiDefaultSatellite";
 import I18nUtil from "@/renderer/common/util/I18nUtil";
+import DigitTextField from "@/renderer/components/atoms/DigitTextField/DigitTextField.vue";
 import TextField from "@/renderer/components/atoms/TextField/TextField.vue";
 import OpeModeSelect from "@/renderer/components/molecules/OpeModeSelect/OpeModeSelect.vue";
 import emitter from "@/renderer/util/EventBus";

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -61,11 +61,11 @@
           </v-col>
           <v-col cols="4">
             <TextField
-              v-model="form.uplink1Mhz"
-              suffix="Mhz"
+              v-model="form.uplink1Hz"
+              suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
-              valiSchemaFieldPath="uplink1Mhz"
-              v-model:error-text="errors.uplink1Mhz"
+              valiSchemaFieldPath="uplink1Hz"
+              v-model:error-text="errors.uplink1Hz"
             />
           </v-col>
           <v-col cols="3"> <OpeModeSelect v-model="form.uplink1Mode" /></v-col>
@@ -76,20 +76,20 @@
           <v-col cols="4"> </v-col>
           <v-col cols="4">
             <TextField
-              v-model="form.uplink2Mhz"
-              suffix="Mhz"
+              v-model="form.uplink2Hz"
+              suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
-              valiSchemaFieldPath="uplink2Mhz"
-              v-model:error-text="errors.uplink2Mhz"
-              :disabled="!(form.uplink1Mhz && form.uplink1Mode)"
+              valiSchemaFieldPath="uplink2Hz"
+              v-model:error-text="errors.uplink2Hz"
+              :disabled="!(form.uplink1Hz && form.uplink1Mode)"
             />
           </v-col>
           <v-col cols="3">
-            <OpeModeSelect v-model="form.uplink2Mode" :disabled="!(form.uplink1Mhz && form.uplink1Mode)"
+            <OpeModeSelect v-model="form.uplink2Mode" :disabled="!(form.uplink1Hz && form.uplink1Mode)"
           /></v-col>
           <v-col col="1">
             <v-radio-group v-model="form.autoModeUplinkFreq" hide-details density="compact">
-              <v-radio value="2" :disabled="!(form.uplink1Mhz && form.uplink1Mode)"></v-radio></v-radio-group
+              <v-radio value="2" :disabled="!(form.uplink1Hz && form.uplink1Mode)"></v-radio></v-radio-group
           ></v-col>
         </v-row>
         <v-row>
@@ -99,11 +99,11 @@
           </v-col>
           <v-col cols="4">
             <TextField
-              v-model="form.downlink1Mhz"
-              suffix="Mhz"
+              v-model="form.downlink1Hz"
+              suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
-              valiSchemaFieldPath="downlink1Mhz"
-              v-model:error-text="errors.downlink1Mhz"
+              valiSchemaFieldPath="downlink1Hz"
+              v-model:error-text="errors.downlink1Hz"
             />
           </v-col>
           <v-col cols="3"> <OpeModeSelect v-model="form.downlink1Mode" /></v-col>
@@ -114,20 +114,20 @@
           <v-col cols="4"> </v-col>
           <v-col cols="4">
             <TextField
-              v-model="form.downlink2Mhz"
-              suffix="Mhz"
+              v-model="form.downlink2Hz"
+              suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
-              valiSchemaFieldPath="downlink2Mhz"
-              v-model:error-text="errors.downlink2Mhz"
-              :disabled="!(form.downlink1Mhz && form.downlink1Mode)"
+              valiSchemaFieldPath="downlink2Hz"
+              v-model:error-text="errors.downlink2Hz"
+              :disabled="!(form.downlink1Hz && form.downlink1Mode)"
             />
           </v-col>
           <v-col cols="3">
-            <OpeModeSelect v-model="form.downlink2Mode" :disabled="!(form.downlink1Mhz && form.downlink1Mode)"
+            <OpeModeSelect v-model="form.downlink2Mode" :disabled="!(form.downlink1Hz && form.downlink1Mode)"
           /></v-col>
           <v-col col="1">
             <v-radio-group v-model="form.autoModeDownlinkFreq" hide-details density="compact">
-              <v-radio value="2" :disabled="!(form.downlink1Mhz && form.downlink1Mode)"></v-radio></v-radio-group
+              <v-radio value="2" :disabled="!(form.downlink1Hz && form.downlink1Mode)"></v-radio></v-radio-group
           ></v-col>
         </v-row>
         <v-row>
@@ -137,11 +137,11 @@
           </v-col>
           <v-col cols="4">
             <TextField
-              v-model="form.toneMhz"
-              suffix="Mhz"
+              v-model="form.toneHz"
+              suffix="Hz"
               :valiSchema="valiSchemaEditSatelliteInfo"
-              valiSchemaFieldPath="toneMhz"
-              v-model:error-text="errors.toneMhz"
+              valiSchemaFieldPath="toneHz"
+              v-model:error-text="errors.toneHz"
             />
           </v-col>
         </v-row>

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -66,6 +66,7 @@
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="uplink1Hz"
               v-model:error-text="errors.uplink1Hz"
+              maxlength="13"
             />
           </v-col>
           <v-col cols="3"> <OpeModeSelect v-model="form.uplink1Mode" /></v-col>
@@ -82,6 +83,7 @@
               valiSchemaFieldPath="uplink2Hz"
               v-model:error-text="errors.uplink2Hz"
               :disabled="!(form.uplink1Hz && form.uplink1Mode)"
+              maxlength="13"
             />
           </v-col>
           <v-col cols="3">
@@ -104,6 +106,7 @@
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="downlink1Hz"
               v-model:error-text="errors.downlink1Hz"
+              maxlength="13"
             />
           </v-col>
           <v-col cols="3"> <OpeModeSelect v-model="form.downlink1Mode" /></v-col>
@@ -120,6 +123,7 @@
               valiSchemaFieldPath="downlink2Hz"
               v-model:error-text="errors.downlink2Hz"
               :disabled="!(form.downlink1Hz && form.downlink1Mode)"
+              maxlength="13"
             />
           </v-col>
           <v-col cols="3">
@@ -142,6 +146,7 @@
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="toneHz"
               v-model:error-text="errors.toneHz"
+              maxlength="13"
             />
           </v-col>
         </v-row>

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfoForm.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfoForm.ts
@@ -9,15 +9,15 @@ export default class EditSatelliteInfoForm {
   public editSatelliteName: string = "";
   public noradId: string = "";
   public autoModeUplinkFreq: string = "1";
-  public uplink1Mhz: number | null = null;
+  public uplink1Hz: number | null = null;
   public uplink1Mode: string = "";
-  public uplink2Mhz: number | null = null;
+  public uplink2Hz: number | null = null;
   public uplink2Mode: string = "";
   public autoModeDownlinkFreq: string = "1";
-  public downlink1Mhz: number | null = null;
+  public downlink1Hz: number | null = null;
   public downlink1Mode: string = "";
-  public downlink2Mhz: number | null = null;
+  public downlink2Hz: number | null = null;
   public downlink2Mode: string = "";
-  public toneMhz: number | null = null;
+  public toneHz: number | null = null;
   public outline: string = "";
 }

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfo.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfo.ts
@@ -15,15 +15,15 @@ export default function useEditSatelliteInfo() {
     targetForm.satelliteId = srcObj.satelliteId;
     // 参照用はここでは設定しない
     targetForm.noradId = srcObj.noradId;
-    targetForm.uplink1Mhz = srcObj.uplink1.uplinkHz;
+    targetForm.uplink1Hz = srcObj.uplink1.uplinkHz;
     targetForm.uplink1Mode = srcObj.uplink1.uplinkMode;
-    targetForm.uplink2Mhz = srcObj.uplink2.uplinkHz;
+    targetForm.uplink2Hz = srcObj.uplink2.uplinkHz;
     targetForm.uplink2Mode = srcObj.uplink2.uplinkMode;
-    targetForm.downlink1Mhz = srcObj.downlink1.downlinkHz;
+    targetForm.downlink1Hz = srcObj.downlink1.downlinkHz;
     targetForm.downlink1Mode = srcObj.downlink1.downlinkMode;
-    targetForm.downlink2Mhz = srcObj.downlink2.downlinkHz;
+    targetForm.downlink2Hz = srcObj.downlink2.downlinkHz;
     targetForm.downlink2Mode = srcObj.downlink2.downlinkMode;
-    targetForm.toneMhz = srcObj.toneMhz;
+    targetForm.toneHz = srcObj.toneHz;
     targetForm.outline = srcObj.outline;
   }
   /**
@@ -58,16 +58,16 @@ export default function useEditSatelliteInfo() {
     targetAppConfig.userRegisteredSatelliteName = srcForm.editSatelliteName;
     targetAppConfig.noradId = srcForm.noradId;
     targetAppConfig.autoModeUplinkFreq = parseInt(srcForm.autoModeUplinkFreq);
-    targetAppConfig.uplink1.uplinkHz = srcForm.uplink1Mhz ? srcForm.uplink1Mhz : null;
+    targetAppConfig.uplink1.uplinkHz = srcForm.uplink1Hz ? srcForm.uplink1Hz : null;
     targetAppConfig.uplink1.uplinkMode = srcForm.uplink1Mode;
-    targetAppConfig.uplink2.uplinkHz = srcForm.uplink2Mhz ? srcForm.uplink2Mhz : null;
+    targetAppConfig.uplink2.uplinkHz = srcForm.uplink2Hz ? srcForm.uplink2Hz : null;
     targetAppConfig.uplink2.uplinkMode = srcForm.uplink2Mode;
     targetAppConfig.autoModeDownlinkFreq = parseInt(srcForm.autoModeDownlinkFreq);
-    targetAppConfig.downlink1.downlinkHz = srcForm.downlink1Mhz ? srcForm.downlink1Mhz : null;
+    targetAppConfig.downlink1.downlinkHz = srcForm.downlink1Hz ? srcForm.downlink1Hz : null;
     targetAppConfig.downlink1.downlinkMode = srcForm.downlink1Mode;
-    targetAppConfig.downlink2.downlinkHz = srcForm.downlink2Mhz ? srcForm.downlink2Mhz : null;
+    targetAppConfig.downlink2.downlinkHz = srcForm.downlink2Hz ? srcForm.downlink2Hz : null;
     targetAppConfig.downlink2.downlinkMode = srcForm.downlink2Mode;
-    targetAppConfig.toneMhz = srcForm.toneMhz ? srcForm.toneMhz : null;
+    targetAppConfig.toneHz = srcForm.toneHz ? srcForm.toneHz : null;
     targetAppConfig.outline = srcForm.outline;
   }
 

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
@@ -69,7 +69,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
       zod
         // 正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => val > 0, {
+          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
             message,
           }),
           zod.null(),
@@ -85,7 +85,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
       zod
         // 正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => val > 0, {
+          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
             message,
           }),
           zod.null(),
@@ -101,7 +101,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
       zod
         // 正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => val > 0, {
+          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
             message,
           }),
           zod.null(),
@@ -117,7 +117,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
       zod
         // 正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => val > 0, {
+          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
             message,
           }),
           zod.null(),
@@ -133,7 +133,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
       zod
         // 正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => val > 0, {
+          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
             message,
           }),
           zod.null(),

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
@@ -23,20 +23,20 @@ export function useEditSatelliteInfoValidate() {
     // 相関チェック
     // アップリンク周波数の周波数かモードの片方が未入力の場合はエラー
     if (
-      (form.uplink1Mhz && !form.uplink1Mode) ||
-      (!form.uplink1Mhz && form.uplink1Mode) ||
-      (form.uplink2Mhz && !form.uplink2Mode) ||
-      (!form.uplink2Mhz && form.uplink2Mode)
+      (form.uplink1Hz && !form.uplink1Mode) ||
+      (!form.uplink1Hz && form.uplink1Mode) ||
+      (form.uplink2Hz && !form.uplink2Mode) ||
+      (!form.uplink2Hz && form.uplink2Mode)
     ) {
       result = false;
       errors.value["uplink"] = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NOT_ENTERED_UPLINK);
     }
     // ダウンリンク周波数の周波数かモードの片方が未入力の場合はエラー
     if (
-      (form.downlink1Mhz && !form.downlink1Mode) ||
-      (!form.downlink1Mhz && form.downlink1Mode) ||
-      (form.downlink2Mhz && !form.downlink2Mode) ||
-      (!form.downlink2Mhz && form.downlink2Mode)
+      (form.downlink1Hz && !form.downlink1Mode) ||
+      (!form.downlink1Hz && form.downlink1Mode) ||
+      (form.downlink2Hz && !form.downlink2Mode) ||
+      (!form.downlink2Hz && form.downlink2Mode)
     ) {
       result = false;
       errors.value["downlink"] = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NOT_ENTERED_DOWNLINK);
@@ -63,7 +63,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
         .regex(/^[A-Za-z0-9&*/ '()+_\[\]-]*$/, { message: message2 })
     );
   }),
-  uplink1Mhz: zod.lazy(() => {
+  uplink1Hz: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
     return (
       zod
@@ -79,7 +79,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
     );
   }),
 
-  uplink2Mhz: zod.lazy(() => {
+  uplink2Hz: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
     return (
       zod
@@ -95,7 +95,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
     );
   }),
 
-  downlink1Mhz: zod.lazy(() => {
+  downlink1Hz: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
     return (
       zod
@@ -111,7 +111,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
     );
   }),
 
-  downlink2Mhz: zod.lazy(() => {
+  downlink2Hz: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
     return (
       zod
@@ -127,7 +127,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
     );
   }),
 
-  toneMhz: zod.lazy(() => {
+  toneHz: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
     return (
       zod

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
@@ -64,7 +64,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
     );
   }),
   uplink1Hz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
     return (
       zod
         // 正の実数か空白
@@ -80,7 +80,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
   }),
 
   uplink2Hz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
     return (
       zod
         // 正の実数か空白
@@ -96,7 +96,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
   }),
 
   downlink1Hz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
     return (
       zod
         // 正の実数か空白
@@ -112,7 +112,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
   }),
 
   downlink2Hz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
     return (
       zod
         // 正の実数か空白
@@ -128,7 +128,7 @@ export const valiSchemaEditSatelliteInfo = zod.object({
   }),
 
   toneHz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
     return (
       zod
         // 正の実数か空白

--- a/src/renderer/components/pages/Home/Home.scss
+++ b/src/renderer/components/pages/Home/Home.scss
@@ -2,7 +2,7 @@
 @import "@/renderer/components/styles/global.scss";
 
 $main_left_satellite_height: 60px;
-$main_right_width: 250px;
+$main_right_width: 260px;
 
 .container {
   position: relative;

--- a/src/renderer/service/ActiveSatServiceHub.ts
+++ b/src/renderer/service/ActiveSatServiceHub.ts
@@ -1,6 +1,5 @@
 import Constant from "@/common/Constant";
 import { DownlinkType, UplinkType } from "@/common/types/satelliteSettingTypes";
-import TransceiverUtil from "@/common/util/TransceiverUtil";
 import ApiActiveSat from "@/renderer/api/ApiActiveSat";
 import ApiAppConfig from "@/renderer/api/ApiAppConfig";
 import ApiAppConfigSatellite from "@/renderer/api/ApiAppConfigSatellite";
@@ -220,39 +219,27 @@ export default class ActiveSatServiceHub {
     if (appConfigSatellite) {
       if (appConfigSatellite.autoModeUplinkFreq === 2) {
         // アップリンク設定が2の場合は、設定2を使用する
-        // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
         this.uplinkFreq = {
-          uplinkHz: appConfigSatellite.uplink2.uplinkHz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink2.uplinkHz)
-            : null,
+          uplinkHz: appConfigSatellite.uplink2.uplinkHz ? appConfigSatellite.uplink2.uplinkHz : null,
           uplinkMode: appConfigSatellite.uplink2.uplinkMode,
         };
       } else {
         // それ以外は設定1を使用する
         this.uplinkFreq = {
-          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
-          uplinkHz: appConfigSatellite.uplink1.uplinkHz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.uplink1.uplinkHz)
-            : null,
+          uplinkHz: appConfigSatellite.uplink1.uplinkHz ? appConfigSatellite.uplink1.uplinkHz : null,
           uplinkMode: appConfigSatellite.uplink1.uplinkMode,
         };
       }
       if (appConfigSatellite.autoModeDownlinkFreq === 2) {
         // ダウンリンク設定が2の場合は、設定2を使用する
         this.downlinkFreq = {
-          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
-          downlinkHz: appConfigSatellite.downlink2.downlinkHz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink2.downlinkHz)
-            : null,
+          downlinkHz: appConfigSatellite.downlink2.downlinkHz ? appConfigSatellite.downlink2.downlinkHz : null,
           downlinkMode: appConfigSatellite.downlink2.downlinkMode,
         };
       } else {
         // それ以外は設定1を使用する
         this.downlinkFreq = {
-          // TODO 変数名はHzだが実際はMhzなのでシステムがHzで扱うようになったらmhzToHzを削除する
-          downlinkHz: appConfigSatellite.downlink1.downlinkHz
-            ? TransceiverUtil.mhzToHz(appConfigSatellite.downlink1.downlinkHz)
-            : null,
+          downlinkHz: appConfigSatellite.downlink1.downlinkHz ? appConfigSatellite.downlink1.downlinkHz : null,
           downlinkMode: appConfigSatellite.downlink1.downlinkMode,
         };
       }


### PR DESCRIPTION
# 前提
- 周波数の単位はMhzで統一していた

# 実装概要
- メインのTx/Rx設定、衛星情報設定画面のアップリンク・ダウンリンク・トーン周波数をHzに修正
- Mhz->Hz、Hz->Mhzの変換処理を削除
- 変数やキー名もHzに統一
- 衛星情報設定画面の周波数設定は3桁区切りを入れた
<img width="1174" alt="スクリーンショット 2025-04-27 6 25 57" src="https://github.com/user-attachments/assets/6a10a911-b600-4497-b70e-6b33a4306a09" />
<img width="600" alt="スクリーンショット 2025-04-27 6 27 30" src="https://github.com/user-attachments/assets/0b85ecc7-1df9-4aba-a334-4779ad4e6702" />


# 注意点
- データ構造が全面的に変更となるためアプリをアップデートする場合は以下のファイルの削除が必要です
  - app_config.json
  - default_satellite.json
  - frequency.json

# 関連
- なし