### PR TITLE
デフォルト衛星定義読み込み時に最新の定義に一致するデータだけ読み込み

### DIFF
--- a/src/__tests__/common/model/DefaultSatelliteModel.test.ts
+++ b/src/__tests__/common/model/DefaultSatelliteModel.test.ts
@@ -171,4 +171,41 @@ describe("DefaultSatelliteModel", () => {
     // Assert
     expect(defSatModel.getDefaultSatelliteBySatelliteId(0)?.satelliteName).toBe("overwrite");
   });
+
+  /**
+   *
+   */
+  test("常に新しい定義でデフォルト衛星情報を初期化する", () => {
+    // Arrange
+    // uplink1がuplinkMhzになっている
+    const data = {
+      defaultSatellite: {
+        defaultSatellites: [
+          {
+            satelliteId: 0,
+            satelliteName: "test",
+            uplink1: { uplinkMhz: null, uplinkMode: "AAA" },
+            uplink2: { uplinkHz: null, uplinkMode: "" },
+            downlink1: { downlinkHz: null, downlinkMode: "" },
+            downlink2: { downlinkHz: null, downlinkMode: "" },
+            toneHz: null,
+            outline: "",
+            noradId: "1",
+          },
+        ],
+        maxSatelliteId: 1,
+        registeredNoradIds: ["1"],
+      },
+    };
+
+    // Act
+    const initilizedModel = DefaultSatelliteModel.getInitializedModelFromData(data.defaultSatellite);
+    const defsat = initilizedModel.getDefaultSatelliteBySatelliteId(0);
+
+    // Assert
+    // 元データはともあれuplinkHzが定義されている
+    expect(defsat).toHaveProperty("uplink1.uplinkHz");
+    // キーが一致しているものは値が引き継げている
+    expect(defsat?.uplink1.uplinkMode).toBe("AAA");
+  });
 });

--- a/src/common/model/DefaultSatelliteModel.ts
+++ b/src/common/model/DefaultSatelliteModel.ts
@@ -1,6 +1,6 @@
 import { TleItemMap } from "@/common/model/TleModel";
 import { DefaultSatelliteType, SatelliteIdentiferType } from "@/common/types/satelliteSettingTypes";
-import { createDefaultSatellite } from "@/common/util/DefaultSatelliteUtil";
+import { createDefaultSatellite, initializeDefaultSatellites, normalizeData } from "@/common/util/DefaultSatelliteUtil";
 
 /**
  * アプリケーション内で管理しておく対象衛星のデフォルト情報
@@ -29,6 +29,23 @@ export class DefaultSatelliteModel {
       null,
       2
     );
+  }
+
+  /**
+   * デフォルト衛星定義のファイルデータからモデルを初期化して生成する
+   * @param data
+   * @returns
+   */
+  public static getInitializedModelFromData(data: any): DefaultSatelliteModel {
+    if (data.defaultSatellites && data.registeredNoradIds && data.maxSatelliteId) {
+      return Object.assign(new DefaultSatelliteModel(), {
+        defaultSatellites: initializeDefaultSatellites(data.defaultSatellites),
+        maxSatelliteId: data.maxSatelliteId,
+        registeredNoradIds: data.registeredNoradIds,
+      });
+    } else {
+      return new DefaultSatelliteModel();
+    }
   }
 
   /**
@@ -142,7 +159,7 @@ export class DefaultSatelliteModel {
     satellites.forEach((sat) => {
       this.defaultSatellites.forEach((defsat) => {
         if (defsat.noradId === sat.noradId) {
-          Object.assign(defsat, sat);
+          Object.assign(defsat, normalizeData(sat, defsat));
         }
       });
     });

--- a/src/common/util/DefaultSatelliteUtil.ts
+++ b/src/common/util/DefaultSatelliteUtil.ts
@@ -24,3 +24,35 @@ export function createDefaultSatellite(
     outline: "",
   };
 }
+
+/**
+ * データを使ってデフォルト衛星情報を初期化する関数
+ * @param defaultSatellites デフォルト衛星情報の配列
+ * @returns
+ */
+export function initializeDefaultSatellites(defaultSatellites: any[]) {
+  return defaultSatellites.map((sat: DefaultSatelliteType) => {
+    return normalizeData(sat, createDefaultSatellite(-1, "", ""));
+  });
+}
+
+/**
+ * 再帰的にキーが存在する場合に値を設定する関数
+ * @param source 入力データ
+ * @param template テンプレートオブジェクト
+ * @returns テンプレートに基づいて正規化されたオブジェクト
+ */
+export function normalizeData(source: any, template: any): any {
+  if (typeof template !== "object" || template === null) {
+    // テンプレートがオブジェクトでない場合はそのまま返す
+    return source ?? template;
+  }
+
+  const result: any = {};
+  for (const key in template) {
+    if (template.hasOwnProperty(key)) {
+      result[key] = normalizeData(source?.[key], template[key]);
+    }
+  }
+  return result;
+}

--- a/src/main/service/DefaultSatelliteService.ts
+++ b/src/main/service/DefaultSatelliteService.ts
@@ -28,7 +28,7 @@ export default class DefaultSatelliteService {
     const savePathSat = path.join(ElectronUtil.getUserDir(), Constant.Config.DEFAULT_SATELLITE_FILENAME);
     if (fs.existsSync(savePathSat)) {
       const fileContentSat = fs.readFileSync(savePathSat, "utf-8");
-      this.defSatJson = Object.assign(new DefaultSatelliteModel(), JSON.parse(fileContentSat).defaultSatellite);
+      this.defSatJson = DefaultSatelliteModel.getInitializedModelFromData(JSON.parse(fileContentSat).defaultSatellite);
     }
   }
 
@@ -51,7 +51,7 @@ export default class DefaultSatelliteService {
     }
 
     const defaultSatData = FileUtil.readJson(savePathSat);
-    this.defSatJson = Object.assign(new DefaultSatelliteModel(), defaultSatData.defaultSatellite);
+    this.defSatJson = DefaultSatelliteModel.getInitializedModelFromData(defaultSatData.defaultSatellite);
 
     // TLEから情報を取得してデフォルト衛星定義を更新する
     for (const tleItem of Object.values(tleItemMap)) {


### PR DESCRIPTION
# 前提
- デフォルト衛星定義はファイル内容をそのまま読み込むようになっていた
- これによりバージョンアップでデフォルト衛星の定義が変更になっても古い定義のキーを使い続ける挙動になっていた

# 実装概要
- Object.assignによるオブジェクトの上書きをやめてキーが存在するか確認して上書きするようにした

# 注意点
- 特になし

# 関連
#7 
