### PR TITLE
#53 トーン周波数は小数点以下の入力を許容

### DIFF
--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -146,7 +146,7 @@
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="toneHz"
               v-model:error-text="errors.toneHz"
-              maxlength="13"
+              maxlength="15"
             />
           </v-col>
         </v-row>

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/useEditSatelliteInfoValidate.ts
@@ -128,14 +128,36 @@ export const valiSchemaEditSatelliteInfo = zod.object({
   }),
 
   toneHz: zod.lazy(() => {
-    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_POSITIVE_INT);
+    const message1 = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_POSITIVE);
+    const message2 = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_DECIMAL, "1");
     return (
       zod
-        // 正の実数か空白
+        // 小数点第1位までの正の実数か空白
         .union([
-          zod.coerce.number().refine((val) => Number.isInteger(val) && val > 0, {
-            message,
-          }),
+          zod.coerce
+            .string()
+            .refine(
+              (value) => {
+                // 小数点第1位までかを確認（小数第2位以降はNG）
+                const decimalPart = value.split(".")[1];
+                if (decimalPart && decimalPart.length > 1) return false;
+
+                return true;
+              },
+              {
+                message: message2,
+              }
+            )
+            .refine(
+              (val) => {
+                // 正の数値かを確認
+                const numVal = parseFloat(val);
+                return !isNaN(numVal) && numVal > 0;
+              },
+              {
+                message: message1,
+              }
+            ),
           zod.null(),
           // 入力をクリアすると空文字となるためこれを許容する
           zod.literal(""),


### PR DESCRIPTION
# 前提
- 周波数は整数値のみを許容していた
# 実装概要
- トーン周波数は小数点第一位までの入力を許容するようにした
![image](https://github.com/user-attachments/assets/942edcd4-1f53-48e0-aa98-f1a944d0438b)

# 注意点
- なし
# 関連
#53 