### PR TITLE
ローテータ設定に仰角の最大最小項目を追加

### DIFF
--- a/src/__tests__/main/validator/data_AppConfigValidator_exec/appVersion_num.json
+++ b/src/__tests__/main/validator/data_AppConfigValidator_exec/appVersion_num.json
@@ -33,6 +33,8 @@
       "basePositionDegree": 0,
       "rangeAzMin": 0,
       "rangeAzMax": 360,
+      "rangeElMin": 0,
+      "rangeElMax": 180,
       "moveMode": "normal",
       "startAgoMinute": 0,
       "parkPosAz": 0,

--- a/src/__tests__/main/validator/data_AppConfigValidator_exec/app_config.json
+++ b/src/__tests__/main/validator/data_AppConfigValidator_exec/app_config.json
@@ -61,6 +61,8 @@
       "basePositionDegree": 0,
       "rangeAzMin": 0,
       "rangeAzMax": 360,
+      "rangeElMin": 0,
+      "rangeElMax": 180,
       "moveMode": "normal",
       "startAgoMinute": 0,
       "parkPosAz": 0,

--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -254,9 +254,10 @@ export default class I18nMsgs {
   public static readonly G51_TEST_MODE: I18nMsgItem = { en: "Test Mode", ja: "テストモード" };
   public static readonly G51_IPADDRESS: I18nMsgItem = { en: "IP Address", ja: "IPアドレス" };
   public static readonly G51_IPADDRESS_PORT: I18nMsgItem = { en: "Port", ja: "Port" };
-  public static readonly G51_AZ_KADO_HANI: I18nMsgItem = { en: "Orientation Range", ja: "方位可動範囲" };
-  public static readonly G51_AZ_KADO_HANI_MIN: I18nMsgItem = { en: "Min", ja: "最小" };
-  public static readonly G51_AZ_KADO_HANI_MAX: I18nMsgItem = { en: "Max", ja: "最大" };
+  public static readonly G51_AZ_KADO_HANI: I18nMsgItem = { en: "Az Range", ja: "方位可動範囲" };
+  public static readonly G51_EL_KADO_HANI: I18nMsgItem = { en: "El Range", ja: "仰角可動範囲" };
+  public static readonly G51_KADO_HANI_MIN: I18nMsgItem = { en: "Min", ja: "最小" };
+  public static readonly G51_KADO_HANI_MAX: I18nMsgItem = { en: "Max", ja: "最大" };
   public static readonly G51_BASE_POSITION_DEGREE: I18nMsgItem = { en: "Base Position", ja: "起点" };
   public static readonly G51_BASE_POSITION_DEGREE_GUIDE: I18nMsgItem = { en: "North is 0°", ja: "北を0°とする" };
   public static readonly G51_MOVE_MODE: I18nMsgItem = { en: "Mode", ja: "モード" };

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -178,6 +178,10 @@ export class AppConfigRotator {
   public rangeAzMin = 0;
   // ローテーター最大方位
   public rangeAzMax = 360;
+  // ローテーター最小仰角
+  public rangeElMin = 0;
+  // ローテーター最大仰角
+  public rangeElMax = 180;
   // 動作モード
   public moveMode = Constant.Config.Rotator.MOVE_MODE_NORMAL;
   // 自動追尾開始分

--- a/src/main/validator/AppConfigValidator.ts
+++ b/src/main/validator/AppConfigValidator.ts
@@ -152,6 +152,8 @@ const schemaRotator = zod.object({
   basePositionDegree: zod.number(),
   rangeAzMin: zod.number(),
   rangeAzMax: zod.number(),
+  rangeElMin: zod.number(),
+  rangeElMax: zod.number(),
   moveMode: zod.string(),
   startAgoMinute: zod.number(),
   parkPosAz: zod.number(),

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehavior.scss
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehavior.scss
@@ -4,9 +4,9 @@
   width: 160px;
 }
 
-.form_label_az_min {
+.form_label_range_min {
   width: 160px;
 }
-.form_label_az_max {
+.form_label_range_max {
   width: 80px;
 }

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehavior.vue
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehavior.vue
@@ -1,6 +1,6 @@
 <template>
-  <!-- 左側 -->
   <v-row>
+    <!-- 左側 -->
     <v-col cols="6">
       <!-- 方位可動範囲 -->
       <div>
@@ -9,8 +9,8 @@
         </div>
         <div class="d-flex">
           <!-- 最小 -->
-          <label class="label form_label_az_min pl-3 g_invalid_item_label"
-            >{{ I18nUtil.getMsg(I18nMsgs.G51_AZ_KADO_HANI_MIN) }}(°)</label
+          <label class="label form_label_range_min pl-3 g_invalid_item_label"
+            >{{ I18nUtil.getMsg(I18nMsgs.G51_KADO_HANI_MIN) }}(°)</label
           >
           <div class="d-flex">
             <TextField
@@ -25,8 +25,8 @@
             />
 
             <!-- 最大 -->
-            <label class="label form_label_az_max text-right g_invalid_item_label"
-              >{{ I18nUtil.getMsg(I18nMsgs.G51_AZ_KADO_HANI_MAX) }}(°)</label
+            <label class="label form_label_range_max text-right g_invalid_item_label"
+              >{{ I18nUtil.getMsg(I18nMsgs.G51_KADO_HANI_MAX) }}(°)</label
             >
             <TextField
               v-model="form.rangeAzMax"
@@ -131,8 +131,48 @@
       </div>
     </v-col>
 
-    <!-- 右側（ダミー） -->
-    <v-col cols="6" />
+    <!-- 右側 -->
+    <v-col cols="6">
+      <!-- 仰角可動範囲 -->
+      <div>
+        <div class="d-flex">
+          <label class="label form_label g_invalid_item_label">{{ I18nUtil.getMsg(I18nMsgs.G51_EL_KADO_HANI) }}</label>
+        </div>
+        <div class="d-flex">
+          <!-- 最小 -->
+          <label class="label form_label_range_min pl-3 g_invalid_item_label"
+            >{{ I18nUtil.getMsg(I18nMsgs.G51_KADO_HANI_MIN) }}(°)</label
+          >
+          <div class="d-flex">
+            <TextField
+              v-model="form.rangeElMin"
+              suffix="°"
+              class="g_right"
+              maxlength="3"
+              :valiSchema="valiSchemaRotatorBehavior"
+              valiSchemaFieldPath="rangeElMin"
+              v-model:error-text="errors.rangeElMin"
+              disabled
+            />
+
+            <!-- 最大 -->
+            <label class="label form_label_range_max text-right g_invalid_item_label"
+              >{{ I18nUtil.getMsg(I18nMsgs.G51_KADO_HANI_MAX) }}(°)</label
+            >
+            <TextField
+              v-model="form.rangeElMax"
+              suffix="°"
+              class="g_right ml-2"
+              maxlength="3"
+              :valiSchema="valiSchemaRotatorBehavior"
+              valiSchemaFieldPath="rangeElMax"
+              v-model:error-text="errors.rangeElMax"
+              disabled
+            />
+          </div>
+        </div>
+      </div>
+    </v-col>
   </v-row>
 </template>
 

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehaviorForm.ts
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/RotatorBehaviorForm.ts
@@ -5,6 +5,8 @@ export default class RotatorBehaviorForm {
   public basePositionDegree = "";
   public rangeAzMin = "";
   public rangeAzMax = "";
+  public rangeElMin = "";
+  public rangeElMax = "";
   public moveMode = "";
   public startAgoMinute = "";
   public parkPosAz = "";

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/useRotatorBehaviorValidate.ts
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorBehavior/useRotatorBehaviorValidate.ts
@@ -37,6 +37,16 @@ export const valiSchemaRotatorBehavior = zod.object({
     return ZodUtil.numRequire(message, 0, azRange.max);
   }),
 
+  rangeElMin: zod.lazy(() => {
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_MIN_MAX, `${elRange.min}`, "0");
+    return ZodUtil.numRequire(message, elRange.min, 0);
+  }),
+
+  rangeElMax: zod.lazy(() => {
+    const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_MIN_MAX, "0", `${elRange.max}`);
+    return ZodUtil.numRequire(message, 0, elRange.max);
+  }),
+
   basePositionDegree: zod.lazy(() => {
     const message = I18nUtil.getMsg(I18nMsgs.CHK_ERR_NUM_MIN_MAX, "0", "360");
     return ZodUtil.num(message, 0, 360);

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorSetting.vue
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorSetting.vue
@@ -121,6 +121,8 @@ async function reloadConfig() {
   form.value.ipPort = CommonUtil.toString(appConfig.rotator.ipPort);
   form.value.rangeAzMin = appConfig.rotator.rangeAzMin.toString();
   form.value.rangeAzMax = appConfig.rotator.rangeAzMax.toString();
+  form.value.rangeElMin = appConfig.rotator.rangeElMin.toString();
+  form.value.rangeElMax = appConfig.rotator.rangeElMax.toString();
   form.value.basePositionDegree = CommonUtil.toString(appConfig.rotator.basePositionDegree);
   form.value.moveMode = appConfig.rotator.moveMode;
   form.value.startAgoMinute = CommonUtil.toString(appConfig.rotator.startAgoMinute);
@@ -153,6 +155,8 @@ async function onOk() {
   rotatorConfig.rotator.basePositionDegree = parseInt(form.value.basePositionDegree);
   rotatorConfig.rotator.rangeAzMin = parseInt(form.value.rangeAzMin);
   rotatorConfig.rotator.rangeAzMax = parseInt(form.value.rangeAzMax);
+  rotatorConfig.rotator.rangeElMin = parseInt(form.value.rangeElMin);
+  rotatorConfig.rotator.rangeElMax = parseInt(form.value.rangeElMax);
   rotatorConfig.rotator.moveMode = form.value.moveMode;
   rotatorConfig.rotator.startAgoMinute = parseInt(form.value.startAgoMinute);
   rotatorConfig.rotator.parkPosAz = parseInt(form.value.parkPosAz);

--- a/src/renderer/components/organisms/setting/RotatorSetting/RotatorSettingForm.ts
+++ b/src/renderer/components/organisms/setting/RotatorSetting/RotatorSettingForm.ts
@@ -8,6 +8,8 @@ export default class RotatorSettingForm extends RotatorConnForm {
   public basePositionDegree = "";
   public rangeAzMin = "";
   public rangeAzMax = "";
+  public rangeElMin = "";
+  public rangeElMax = "";
   public moveMode = "";
   public startAgoMinute = "";
   public parkPosAz = "";


### PR DESCRIPTION
- ローテータ設定画面の動作設定タブに仰角可動範囲（Min、Max）を追加。
- AppConfig に以下２項目を追加し、保存を可能とした。
　rangeElMin、rangeElMax