### PR TITLE
起動時に例外があったらトーストを表示するように修正

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,6 +1,8 @@
 // mainプロセスでのimportでaliasを適用するために以下の module-alias を使用
 import "module-alias/register";
 // このコメント行は、 module-alias を先頭のままとするためのものです。（import整形で順序を変更させない）
+import Constant from "@/common/Constant";
+import { MessageModel } from "@/common/model/MessageModel";
 import EnvUtil from "@/common/util/EnvUtil";
 import { initializeIpcEvents, releaseIpcEvents } from "@/main/initializeIpcEvent";
 import { makeElectronMenu } from "@/main/menu";
@@ -29,7 +31,14 @@ let mainWindow: BrowserWindow;
 
   // アプリ関係の初期化処理
   const serive = new StartupService();
-  await serive.initApp();
+  // アプリ初期化時にTLE取得に失敗する場合があるためtry-catchで囲む
+  let errorMessage: string | undefined;
+  try {
+    await serive.initApp();
+  } catch (e) {
+    AppMainLogger.error("StartupService init error", e instanceof Error ? e.stack ?? e.message : String(e));
+    errorMessage = e instanceof Error ? e.message : String(e);
+  }
 
   // メニュー設定
   // memo: makeElectronMenu()内でapp_configを参照しているため、
@@ -51,6 +60,13 @@ let mainWindow: BrowserWindow;
     const menuTemplate = buildMenuTemplate(params);
     const contextMenu = Menu.buildFromTemplate(menuTemplate);
     contextMenu.popup();
+  });
+
+  // アプリ初期化時に例外が発生した場合は、mainWindowが読み込み終わってからエラーメッセージを表示する
+  mainWindow.webContents.on("did-finish-load", () => {
+    if (errorMessage) {
+      fireIpcEvent("onNoticeMessage", new MessageModel(Constant.GlobalEvent.NOTICE_ERR, errorMessage));
+    }
   });
 })();
 

--- a/src/main/service/TleService.ts
+++ b/src/main/service/TleService.ts
@@ -102,9 +102,15 @@ export default class TleService {
    * @returns
    */
   private async getTleTextByUrl(url: string, webClient: WebClient): Promise<string> {
-    const res = await webClient.get(url);
+    let res;
+    try {
+      res = await webClient.get(url);
+    } catch (e) {
+      throw new Error(`指定のURLでTLEが取得できませんでした: ${url}`);
+    }
+
     if (res.status !== 200) {
-      AppMainLogger.warn(`指定のURLでTLEが取得できませんでした。 ${res.status} ${url} `);
+      AppMainLogger.warn(`指定のURLでTLEが取得できませんでした: ${res.status} ${url} `);
       return "";
     }
     if (!CommonUtil.isEmpty(res.data.trim())) {

--- a/src/main/service/TleService.ts
+++ b/src/main/service/TleService.ts
@@ -106,7 +106,7 @@ export default class TleService {
     try {
       res = await webClient.get(url);
     } catch (e) {
-      throw new Error(`指定のURLでTLEが取得できませんでした: ${url}`);
+      throw new Error(`Could not access the URL: ${url}`);
     }
 
     if (res.status !== 200) {


### PR DESCRIPTION
# 前提
- 起動時にエラーが起きたらアプリが起動しなかった
 
# 実装概要
- 起動処理にtry/catchをつけて例外を処理できるようにした
- ウィンドウ生成を待って画面側にメッセージイベントを送信
<img width="1668" height="1574" alt="image" src="https://github.com/user-attachments/assets/75fb232c-dd8d-4cb4-a38c-1d83ce700da3" />

# 注意点
- メッセージはTLEのURLがアクセスできなかった場合のみ加工している
- それ以外は例外メッセージがそのまま表示される
- 起動時のエラーをまるっとtry/catchしているが起動時の処理はTLE取得とデフォルト衛星の取得であるため起動後にURLを修正しなせばリカバリー可能(異常なアプリ状態で起動することはなさそう)

# 関連
- なし