### PR TITLE
MhzをMHzに修正

### DIFF
--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -63,7 +63,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.uplink1Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="uplink1Mhz"
               v-model:error-text="errors.uplink1Mhz"
@@ -80,7 +80,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.uplink2Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="uplink2Mhz"
               v-model:error-text="errors.uplink2Mhz"
@@ -100,7 +100,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.uplink3Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="uplink3Mhz"
               v-model:error-text="errors.uplink3Mhz"
@@ -141,7 +141,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.downlink1Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="downlink1Mhz"
               v-model:error-text="errors.downlink1Mhz"
@@ -158,7 +158,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.downlink2Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="downlink2Mhz"
               v-model:error-text="errors.downlink2Mhz"
@@ -178,7 +178,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.downlink3Mhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="downlink3Mhz"
               v-model:error-text="errors.downlink3Mhz"
@@ -202,7 +202,7 @@
           <v-col cols="4">
             <TextField
               v-model="form.beaconMhz"
-              suffix="Mhz"
+              suffix="MHz"
               :valiSchema="valiSchemaEditSatelliteInfo"
               valiSchemaFieldPath="beaconMhz"
               v-model:error-text="errors.beaconMhz"
@@ -421,3 +421,4 @@ async function onReset() {
 <style lang="scss" scoped>
 @import "./EditSatelliteInfo.scss";
 </style>
+


### PR DESCRIPTION
# 前提
- 衛星の周波数設定画面では周波数をMhz表記としていた

# 実装概要
- MHzに修正
- 
<img width="600" height="740" alt="image" src="https://github.com/user-attachments/assets/560fa28e-5531-4901-aa2d-3e06002f9538" />


# 注意点
- なし

# 関連
- なし