### PR TITLE
衛星固定のレイアウト変更

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
@@ -144,6 +144,13 @@
   margin-top: 1px;
 }
 
+.doppler_area {
+  user-select: none;
+  margin-right: 7px;
+  margin-left: 7px;
+  margin-bottom: 7px;
+}
+
 .freq_area {
   user-select: none;
   display: inline-block;
@@ -185,3 +192,4 @@
 .br_no_select {
   user-select: none;
 }
+

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -8,12 +8,15 @@
       @click="autoBtnClick"
       >Auto</Button
     >
-    <!-- ドップラーシフトモード-->
-    <DopplerShiftModeSelect class="doppler_shift_mode_select" v-model="dopplerShiftMode" />
 
     <!-- 無線機・周波数 -->
     <fieldset class="fieldset_area">
       <legend class="item_group_legend">Frequency</legend>
+      <!-- ドップラーシフトモード-->
+      <div class="doppler_area">
+        <DopplerShiftModeSelect class="doppler_shift_mode_select" v-model="dopplerShiftMode" />
+      </div>
+      <!-- 周波数 -->
       <div class="freq_area">
         <div>
           Rx<FrequencySelect class="freq_box" v-model:frequency="rxFrequency" v-model:diffFrequency="diffRxFrequency"
@@ -28,6 +31,7 @@
           >
         </div>
       </div>
+      <!-- ビーコン -->
       <div class="beacon_btn_right">
         <Button
           class="beacon_btn"
@@ -240,3 +244,4 @@ async function beaconBtnClick() {
 <style lang="scss" scoped>
 @import "./TransceiverCtrl.scss";
 </style>
+


### PR DESCRIPTION
# 前提
- 衛星固定のプルダウンは周波数の枠の外側にいた

# 実装概要
- 周波数の枠の中に変更
<img width="472" height="546" alt="image" src="https://github.com/user-attachments/assets/18548e4c-e856-42f1-b227-d5a97ca9ea3c" />

# 注意点
- なし

# 関連
- なし