### PR TITLE
satelliteモードを切り替えるとrxモード空欄になる

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -721,6 +721,12 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     switch (mode) {
       case Constant.Transceiver.SatelliteMode.SATELLITE:
         isSatTrackingModeNormal.value = state.isSatTrackingModeNormal;
+        // このモード以外はtx/rxが同期している
+        // モードを切り替えるとsatelliteにしたときにrx設定あり->rxが空欄という挙動になる
+        // tx入力してるのにrxを空欄にしたいというケースはないので、txをrxに合わせる
+        const isRxOpeModeUNSET: boolean = rxOpeMode.value === Constant.Transceiver.OpeMode.UNSET;
+        const isTxOpeModeUNSET: boolean = txOpeMode.value === Constant.Transceiver.OpeMode.UNSET;
+        if (isRxOpeModeUNSET && !isTxOpeModeUNSET) rxOpeMode.value = txOpeMode.value;
         break;
       case Constant.Transceiver.SatelliteMode.SPLIT:
         isSatTrackingModeNormal.value = true; // SPLITモードではトラッキングモードは常にNORMAL
@@ -750,3 +756,4 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 };
 
 export default useTransceiverCtrl;
+


### PR DESCRIPTION
# 前提
- satelliteモードを切り替えるとrxモード空欄になる
- rxモードは前回選択時の値を記録している
- satelliteモード以外はrxモード/txモードが同期しているので、初回選択時でもtxモードに値が入っていればtxモードと同じ値
- satelliteモードではrxモードとtxモードが同期していないので、初回選択時は空欄になる(初回が空欄だと次回以降も空欄)
# 実装概要
- satelliteモード時にtxモードを設定しているのにrxモードを空欄にしたい可能性は低いと考えられるため、satelliteモード切り替え時にrxモードが空欄の時はtxモードの値を設定する
# 注意点
- なし
# 関連
- なし