### PR TITLE
（開発環境の設定）最終行のNewLine設定で空行が２行生成させるため設定を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,9 @@
   },
   "typescript.preferences.importModuleSpecifier": "non-relative",
   // すべてのTypeScriptの静的解析エラーが問題タブに表示されるようにする
-  "typescript.tsserver.experimental.enableProjectDiagnostics": true
+  "typescript.tsserver.experimental.enableProjectDiagnostics": true,
+  // 最終行の改行はPrettierの設定を優先する
+  "files.insertFinalNewline": false,
+  // 不要な最終行の改行は削除する
+  "files.trimFinalNewlines": true
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -7,5 +7,6 @@
   "moduleNameMapper": {
     "^@/(.*)$": "<rootDir>/src/$1"
   },
-  "testPathIgnorePatterns": ["<rootDir>/src/__tests__/playwright/"]
+  "testPathIgnorePatterns": ["<rootDir>/src/__tests__/playwright/"],
+  "setupFilesAfterEnv": ["<rootDir>/jest.setup.js"]
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+// jest.setup.js
+// console.warnの標準出力を無効化
+global.console.warn = jest.fn();


### PR DESCRIPTION
Prettierにて、最終行のNewLine設定が行われるようになったが、空行が２行生成させるため、空行は１行のみ生成されるように設定を追加。