### PR TITLE
Txの切り替えをできるだけ短くし、Rxの状態を長く保つ

### DIFF
--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -280,7 +280,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
       await this.sendFreq(this.state.getReqTxFreqHz());
       this.state.isTxSendFreqUpdate = false;
     } else if (this.state.isTxRecvFreqUpdate) {
-      // Rx周波数を無線機から取得
+      // Tx周波数を無線機から取得
       // memo: RST側から設定した直後は、基本的に同じ値が返ってくるため、周波数の取得は行わない
       const recvDataSubFreq = await this.sendAndWaitRecv(this.cmdMaker.getFreq(), "GET_FREQ");
       await this.handleRecvData(recvDataSubFreq);

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -106,12 +106,10 @@ export default class TransceiverIcomController extends TransceiverSerialControll
 
       // サテライトモードの場合のみ、サブの処理を一瞬だけ実行
       if (this.state.isSatelliteMode) {
-        AppMainLogger.info(`　　サブ`);
         await this.sendAndRecv(false);
       }
 
       // メインの処理を実行
-      AppMainLogger.info(`　　メイン`);
       await this.sendAndRecv(true);
 
       isProcessing = false;

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -15,7 +15,7 @@ import AppMainLogger from "@/main/util/AppMainLogger";
 // 受信タイムアウト（秒）（起動時）
 const RECV_TIEOUT_SEC_FOR_BOOT = 2;
 // 受信タイムアウト（ミリ秒）（通常のデータ受信時）
-const RECV_TIEOUT_MSEC = 250;
+const RECV_TIMEOUT_MSEC = 250;
 
 // コマンド種別
 type CommandType = "GET_FREQ" | "GET_MODE" | "SET_FREQ" | "SET_MODE" | "SWITCH";
@@ -505,7 +505,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
 
         resetCallback();
         resolve("");
-      }, RECV_TIEOUT_MSEC);
+      }, RECV_TIMEOUT_MSEC);
 
       // 応答なしのコマンドは、送信後に処理を終了する
       if (!this.recvCallbackType.isResponsive) {

--- a/src/main/service/transceiver/controller/TransceiverIcomState.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomState.ts
@@ -18,25 +18,25 @@ export default class TransceiverIcomState {
   private recvRxFreqHz = 0;
 
   // 更新フラグ
-  public isTxFreqUpdate = false;
-  public isRxFreqUpdate = false;
-  public isRxModeUpdate = false;
-  public isTxModeUpdate = false;
-  public isRecvTxFreqUpdate = false;
-  public isRecvRxFreqUpdate = false;
+  public isTxSendFreqUpdate = false;
+  public isRxSendFreqUpdate = false;
+  public isRxSendModeUpdate = false;
+  public isTxSendModeUpdate = false;
+  public isTxRecvFreqUpdate = false;
+  public isRxRecvFreqUpdate = false;
 
   /**
    * Rx（メインバンド）の周波数、モードが更新されているかを返す
    */
   public isRxUpdate(): boolean {
-    return this.isRxFreqUpdate || this.isRxModeUpdate || this.isRecvRxFreqUpdate;
+    return this.isRxSendFreqUpdate || this.isRxSendModeUpdate || this.isRxRecvFreqUpdate;
   }
 
   /**
    * Tx（サブバンド）の周波数、モードが更新されているかを返す
    */
   public isTxUpdate(): boolean {
-    return this.isTxFreqUpdate || this.isTxModeUpdate || this.isRecvTxFreqUpdate;
+    return this.isTxSendFreqUpdate || this.isTxSendModeUpdate || this.isTxRecvFreqUpdate;
   }
 
   /**
@@ -48,7 +48,7 @@ export default class TransceiverIcomState {
       return;
     }
     this.reqRxFreqHz = freqHz;
-    this.isRxFreqUpdate = true;
+    this.isRxSendFreqUpdate = true;
   }
 
   /**
@@ -60,7 +60,7 @@ export default class TransceiverIcomState {
       return;
     }
     this.reqTxFreqHz = freq;
-    this.isTxFreqUpdate = true;
+    this.isTxSendFreqUpdate = true;
   }
 
   /**
@@ -72,7 +72,7 @@ export default class TransceiverIcomState {
       return;
     }
     this.reqRxMode = mode;
-    this.isRxModeUpdate = true;
+    this.isRxSendModeUpdate = true;
   }
 
   /**
@@ -84,7 +84,7 @@ export default class TransceiverIcomState {
       return;
     }
     this.reqTxMode = mode;
-    this.isTxModeUpdate = true;
+    this.isTxSendModeUpdate = true;
   }
 
   /**
@@ -96,9 +96,9 @@ export default class TransceiverIcomState {
       return;
     }
     this.recvRxFreqHz = freq;
-    this.isRecvRxFreqUpdate = true;
+    this.isRxRecvFreqUpdate = true;
     // 無線機での周波数変更は片側の変更のみが通知されるため、Tx側の周波数も更新されたものとして、データ取得対象としておく
-    this.isRecvTxFreqUpdate = true;
+    this.isTxRecvFreqUpdate = true;
   }
 
   /**
@@ -110,19 +110,19 @@ export default class TransceiverIcomState {
       return;
     }
     this.recvTxFreqHz = freq;
-    this.isRecvTxFreqUpdate = true;
+    this.isTxRecvFreqUpdate = true;
     // 無線機での周波数変更は片側の変更のみが通知されるため、Rx側の周波数も更新されたものとして、データ取得対象としておく
-    this.isRecvRxFreqUpdate = true;
+    this.isRxRecvFreqUpdate = true;
   }
 
   /**
    * Rx（メインバンド）の周波数、モードの更新状態をリセットする
    */
   public resetRx(): void {
-    this.isRxFreqUpdate = false;
-    this.isRxModeUpdate = false;
-    this.isRecvRxFreqUpdate = false;
-    this.isRecvTxFreqUpdate = false;
+    this.isRxSendFreqUpdate = false;
+    this.isRxSendModeUpdate = false;
+    this.isRxRecvFreqUpdate = false;
+    this.isTxRecvFreqUpdate = false;
   }
 
   /**
@@ -130,10 +130,10 @@ export default class TransceiverIcomState {
    */
   public resetTx(): void {
     this.reqTxMode = "";
-    this.isTxFreqUpdate = false;
-    this.isTxModeUpdate = false;
-    this.isRecvTxFreqUpdate = false;
-    this.isRecvRxFreqUpdate = false;
+    this.isTxSendFreqUpdate = false;
+    this.isTxSendModeUpdate = false;
+    this.isTxRecvFreqUpdate = false;
+    this.isRxRecvFreqUpdate = false;
   }
 
   /**

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -527,6 +527,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     if (txFrequency.value === newRxFrequency) return;
     txFrequency.value = newRxFrequency;
   });
+
   /**
    * Rx運用モードを同期する
    * サテライトモードがONの場合はTx運用モードを同期しない
@@ -545,6 +546,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     if (txOpeMode.value === newRxOpeMode) return;
     txOpeMode.value = newRxOpeMode;
   });
+
   /**
    * 周波数の更新を行う
    */
@@ -738,6 +740,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     };
     save(mode, state);
   }
+
   /**
    * モードごとの状態を呼び出す
    * @param mode モード名（サテライトモードやSPLITなど）


### PR DESCRIPTION
RSTから無線機への周波数の送信において、一定時間ごとに送信対象とするRxとTxの切り替えを行っていた。
その場合、無線機でのダイアル操作などで周波数を調整する際に意図しないTx/Rxの周波数を変更してしまうことになる。
これの対処としてTxへの切り替えはRxの処理前に一瞬だけ行うように変更。

またその他、変数名の改善、コメントの追加・修正を行った。