### PR TITLE
SPLITは未実装のためグレーアウト

### DIFF
--- a/src/renderer/components/molecules/CycleButton/CycleButton.vue
+++ b/src/renderer/components/molecules/CycleButton/CycleButton.vue
@@ -34,11 +34,12 @@ watch(
         btnClass.value = "btn_on";
         subTextClass.value = "grayed_out_on";
         break;
+      // TODO SPLITモード未対応のため一旦btn_off、grayed_out_offで対応
       case modeRange.value[1]:
         mainText.value = modeRange.value[1];
         subText.value = modeRange.value[0];
-        btnClass.value = "btn_on";
-        subTextClass.value = "grayed_out_on";
+        btnClass.value = "btn_off";
+        subTextClass.value = "grayed_out_off";
         break;
       default:
         mainText.value = modeRange.value[0];


### PR DESCRIPTION
# 前提
- SPLITは未実装

# 実装概要
- 無線機制御画面にてSPLITモード時は何もしないことを見せるためにグレーボタンとした
<img width="472" height="460" alt="image" src="https://github.com/user-attachments/assets/04c84272-dd34-4476-ad55-d7da83f0ad2f" />

# 注意点
- なし

# 関連
- 20250831議事録