### PR TITLE
起動時エラー表示のタイミングをdid-load-finishからready-to-showに変更

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -63,7 +63,7 @@ let mainWindow: BrowserWindow;
   });
 
   // アプリ初期化時に例外が発生した場合は、mainWindowが読み込み終わってからエラーメッセージを表示する
-  mainWindow.webContents.on("did-finish-load", () => {
+  mainWindow.once("ready-to-show", () => {
     if (errorMessage) {
       fireIpcEvent("onNoticeMessage", new MessageModel(Constant.GlobalEvent.NOTICE_ERR, errorMessage));
     }


### PR DESCRIPTION
# 前提
- 起動時のエラー表示のタイミングをdid-load-finish（リソースがロードできたタイミング）としていた

# 実装概要
- エラーが出ない場合があるので画面にある程度レンダリングができたタイミングであるready-to-showに変更

# 注意点
- なし

# 関連
- なし