### PR TITLE
グループごとに衛星情報を管理できるようにする

### DIFF
--- a/src/__tests__/main/service/AppConfigSatelliteService.test.ts
+++ b/src/__tests__/main/service/AppConfigSatelliteService.test.ts
@@ -4,6 +4,10 @@ import AppConfigSatelliteService from "@/main/service/AppConfigSatelliteService"
 import DefaultSatelliteService from "@/main/service/DefaultSatelliteService";
 import { AppConfigUtil } from "@/main/util/AppConfigUtil";
 
+const DEFAULT_SATELLITE_ID = 0;
+const DEFAULT_NORAD_ID = "00000";
+const APPCONFIG_SATELLITE_ID = 1;
+const APPCONFIG_NORAD_ID = "12345";
 describe("AppConfigSatelliteService", () => {
   beforeAll(() => {
     jest.spyOn(DefaultSatelliteService.prototype, "init").mockImplementation(() => {
@@ -13,13 +17,13 @@ describe("AppConfigSatelliteService", () => {
       .spyOn(DefaultSatelliteService.prototype, "getDefaultSatelliteBySatelliteIdSync")
       .mockImplementation((satelliteId: number) => {
         // デフォルト衛星は衛星IDを任意指定
-        return createDefaultSatellite(satelliteId, "TEST_SAT", "00000");
+        return createDefaultSatellite(satelliteId, "TEST_SAT", DEFAULT_NORAD_ID);
       });
     jest.spyOn(AppConfigUtil, "getConfig").mockImplementation(() => {
       const model: AppConfigSatellite = new AppConfigSatellite();
       // アプリケーション設定の衛星は衛星ID=1で固定
-      model.satelliteId = 1;
-      model.noradId = "12345";
+      model.satelliteId = APPCONFIG_SATELLITE_ID;
+      model.noradId = APPCONFIG_NORAD_ID;
       return { satellites: [model] } as any;
     });
   });
@@ -27,16 +31,16 @@ describe("AppConfigSatelliteService", () => {
     // 準備
     const appConfigSatelliteService = new AppConfigSatelliteService();
     // 実行
-    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(0);
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(DEFAULT_SATELLITE_ID);
     // 検証
-    expect(result?.noradId).toBe("00000");
+    expect(result?.noradId).toBe(DEFAULT_NORAD_ID);
   });
   it("アプリケーション設定を取得", () => {
     // 準備
     const appConfigSatelliteService = new AppConfigSatelliteService();
     // 実行
-    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(1);
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(APPCONFIG_SATELLITE_ID);
     // 検証
-    expect(result?.noradId).toBe("12345");
+    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID);
   });
 });

--- a/src/__tests__/main/service/AppConfigSatelliteService.test.ts
+++ b/src/__tests__/main/service/AppConfigSatelliteService.test.ts
@@ -1,0 +1,42 @@
+import { AppConfigSatellite } from "@/common/model/AppConfigModel";
+import { createDefaultSatellite } from "@/common/util/DefaultSatelliteUtil";
+import AppConfigSatelliteService from "@/main/service/AppConfigSatelliteService";
+import DefaultSatelliteService from "@/main/service/DefaultSatelliteService";
+import { AppConfigUtil } from "@/main/util/AppConfigUtil";
+
+describe("AppConfigSatelliteService", () => {
+  beforeAll(() => {
+    jest.spyOn(DefaultSatelliteService.prototype, "init").mockImplementation(() => {
+      return;
+    });
+    jest
+      .spyOn(DefaultSatelliteService.prototype, "getDefaultSatelliteBySatelliteIdSync")
+      .mockImplementation((satelliteId: number) => {
+        // デフォルト衛星は衛星IDを任意指定
+        return createDefaultSatellite(satelliteId, "TEST_SAT", "00000");
+      });
+    jest.spyOn(AppConfigUtil, "getConfig").mockImplementation(() => {
+      const model: AppConfigSatellite = new AppConfigSatellite();
+      // アプリケーション設定の衛星は衛星ID=1で固定
+      model.satelliteId = 1;
+      model.noradId = "12345";
+      return { satellites: [model] } as any;
+    });
+  });
+  it("デフォルト衛星を取得", () => {
+    // 準備
+    const appConfigSatelliteService = new AppConfigSatelliteService();
+    // 実行
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(0);
+    // 検証
+    expect(result?.noradId).toBe("00000");
+  });
+  it("アプリケーション設定を取得", () => {
+    // 準備
+    const appConfigSatelliteService = new AppConfigSatelliteService();
+    // 実行
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(1);
+    // 検証
+    expect(result?.noradId).toBe("12345");
+  });
+});

--- a/src/__tests__/main/service/AppConfigSatelliteService.test.ts
+++ b/src/__tests__/main/service/AppConfigSatelliteService.test.ts
@@ -7,7 +7,8 @@ import { AppConfigUtil } from "@/main/util/AppConfigUtil";
 const DEFAULT_SATELLITE_ID = 0;
 const DEFAULT_NORAD_ID = "00000";
 const APPCONFIG_SATELLITE_ID = 1;
-const APPCONFIG_NORAD_ID = "12345";
+const APPCONFIG_NORAD_ID1 = "12345";
+const APPCONFIG_NORAD_ID2 = "54321";
 describe("AppConfigSatelliteService", () => {
   beforeAll(() => {
     jest.spyOn(DefaultSatelliteService.prototype, "init").mockImplementation(() => {
@@ -16,31 +17,45 @@ describe("AppConfigSatelliteService", () => {
     jest
       .spyOn(DefaultSatelliteService.prototype, "getDefaultSatelliteBySatelliteIdSync")
       .mockImplementation((satelliteId: number) => {
-        // デフォルト衛星は衛星IDを任意指定
         return createDefaultSatellite(satelliteId, "TEST_SAT", DEFAULT_NORAD_ID);
       });
     jest.spyOn(AppConfigUtil, "getConfig").mockImplementation(() => {
-      const model: AppConfigSatellite = new AppConfigSatellite();
-      // アプリケーション設定の衛星は衛星ID=1で固定
-      model.satelliteId = APPCONFIG_SATELLITE_ID;
-      model.noradId = APPCONFIG_NORAD_ID;
-      return { satellites: [model] } as any;
+      const sat1: AppConfigSatellite = new AppConfigSatellite();
+      sat1.satelliteId = APPCONFIG_SATELLITE_ID;
+      sat1.noradId = APPCONFIG_NORAD_ID1;
+      sat1.groupId = 1;
+      const sat2: AppConfigSatellite = new AppConfigSatellite();
+      sat2.satelliteId = APPCONFIG_SATELLITE_ID;
+      sat2.noradId = APPCONFIG_NORAD_ID2;
+      sat2.groupId = 2;
+      return { satellites: [sat1, sat2] } as any;
     });
   });
   it("デフォルト衛星を取得", () => {
     // 準備
     const appConfigSatelliteService = new AppConfigSatelliteService();
+    const groupdId = -1;
     // 実行
-    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(DEFAULT_SATELLITE_ID);
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(DEFAULT_SATELLITE_ID, groupdId);
     // 検証
     expect(result?.noradId).toBe(DEFAULT_NORAD_ID);
   });
-  it("アプリケーション設定を取得", () => {
+  it("アプリケーション設定を取得(グループ一致)", () => {
     // 準備
     const appConfigSatelliteService = new AppConfigSatelliteService();
+    const groupId = 2;
     // 実行
-    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(APPCONFIG_SATELLITE_ID);
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(APPCONFIG_SATELLITE_ID, groupId);
     // 検証
-    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID);
+    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID2);
+  });
+  it("アプリケーション設定を取得(グループ不一致なので最初にヒットした設定)", () => {
+    // 準備
+    const appConfigSatelliteService = new AppConfigSatelliteService();
+    const groupId = 3;
+    // 実行
+    const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(APPCONFIG_SATELLITE_ID, groupId);
+    // 検証
+    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID1);
   });
 });

--- a/src/__tests__/main/service/AppConfigSatelliteService.test.ts
+++ b/src/__tests__/main/service/AppConfigSatelliteService.test.ts
@@ -1,4 +1,5 @@
 import { AppConfigSatellite } from "@/common/model/AppConfigModel";
+import { DefaultSatelliteModel } from "@/common/model/DefaultSatelliteModel";
 import { createDefaultSatellite } from "@/common/util/DefaultSatelliteUtil";
 import AppConfigSatelliteService from "@/main/service/AppConfigSatelliteService";
 import DefaultSatelliteService from "@/main/service/DefaultSatelliteService";
@@ -9,13 +10,14 @@ const DEFAULT_NORAD_ID = "00000";
 const APPCONFIG_SATELLITE_ID = 1;
 const APPCONFIG_NORAD_ID1 = "12345";
 const APPCONFIG_NORAD_ID2 = "54321";
+const APPCONFIG_NORAD_ID3 = "99999";
 describe("AppConfigSatelliteService", () => {
   beforeAll(() => {
     jest.spyOn(DefaultSatelliteService.prototype, "init").mockImplementation(() => {
       return;
     });
     jest
-      .spyOn(DefaultSatelliteService.prototype, "getDefaultSatelliteBySatelliteIdSync")
+      .spyOn(DefaultSatelliteModel.prototype, "getDefaultSatelliteBySatelliteId")
       .mockImplementation((satelliteId: number) => {
         return createDefaultSatellite(satelliteId, "TEST_SAT", DEFAULT_NORAD_ID);
       });
@@ -28,7 +30,11 @@ describe("AppConfigSatelliteService", () => {
       sat2.satelliteId = APPCONFIG_SATELLITE_ID;
       sat2.noradId = APPCONFIG_NORAD_ID2;
       sat2.groupId = 2;
-      return { satellites: [sat1, sat2] } as any;
+      const sat3: AppConfigSatellite = new AppConfigSatellite();
+      sat3.satelliteId = APPCONFIG_SATELLITE_ID;
+      sat3.noradId = APPCONFIG_NORAD_ID3;
+      sat3.groupId = -1;
+      return { satellites: [sat1, sat2, sat3] } as any;
     });
   });
   it("デフォルト衛星を取得", () => {
@@ -49,13 +55,13 @@ describe("AppConfigSatelliteService", () => {
     // 検証
     expect(result?.noradId).toBe(APPCONFIG_NORAD_ID2);
   });
-  it("アプリケーション設定を取得(グループ不一致なので最初にヒットした設定)", () => {
+  it("アプリケーション設定を取得(グループ不一致なのでデフォルト衛星取得)", () => {
     // 準備
     const appConfigSatelliteService = new AppConfigSatelliteService();
     const groupId = 3;
     // 実行
     const result = appConfigSatelliteService.getUserRegisteredAppConfigSatellite(APPCONFIG_SATELLITE_ID, groupId);
     // 検証
-    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID1);
+    expect(result?.noradId).toBe(APPCONFIG_NORAD_ID3);
   });
 });

--- a/src/__tests__/main/util/AppConfigUtil.test.ts
+++ b/src/__tests__/main/util/AppConfigUtil.test.ts
@@ -1,0 +1,33 @@
+import { AppConfigSatellite } from "@/common/model/AppConfigModel";
+import { AppConfigUtil } from "@/main/util/AppConfigUtil";
+
+describe("AppConfigUtil", () => {
+  beforeAll(() => {
+    jest.spyOn(AppConfigUtil, "getConfig").mockImplementation(() => {
+      const sat: AppConfigSatellite = new AppConfigSatellite();
+      sat.satelliteId = 12345;
+      sat.groupId = 1;
+      return { satellites: [sat] } as any;
+    });
+  });
+
+  it("検索がヒットする", () => {
+    // 準備
+    const satelliteId = 12345;
+    const groupId = 1;
+    // 実行
+    const result = AppConfigUtil.searchAppConfigSatellite(satelliteId, groupId);
+    // 検証
+    expect(result?.satelliteId).toBe(satelliteId);
+    expect(result?.groupId).toBe(groupId);
+  });
+  it("検索がヒットしない", () => {
+    // 準備
+    const satelliteId = 12345;
+    const groupId = 2;
+    // 実行
+    const result = AppConfigUtil.searchAppConfigSatellite(satelliteId, groupId);
+    // 検証
+    expect(result).toBeNull();
+  });
+});

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -2,7 +2,7 @@
  * 定数
  */
 export default class Constant {
-  public static readonly appVersion = "v0.1.2a";
+  public static readonly appVersion = "v0.1.3";
 
   /**
    * ロガー関係

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -332,6 +332,9 @@ export default class Constant {
     // 周波数設定ファイルのURL
     static readonly FREQUENCY_URL =
       "https://raw.githubusercontent.com/RymansatSatelliteTracker/RST/refs/heads/main/satellite_data/frequency.json";
+
+    // デフォルトの衛星グループID
+    static readonly DEFAULT_SATELLITE_GROUP_ID = -1;
   };
 
   /**

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -65,7 +65,7 @@ export class AppConfigSatellite {
   // 衛星ID
   public satelliteId: number = -1;
   // グループID
-  public groupId: number = -1;
+  public groupId: number = Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID;
   // ユーザ登録衛星フラグ
   public userRegistered = false;
   //ユーザ登録衛星名

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -64,6 +64,8 @@ export class AppConfigTleUrl {
 export class AppConfigSatellite {
   // 衛星ID
   public satelliteId: number = -1;
+  // グループID
+  public groupId: number = -1;
   // ユーザ登録衛星フラグ
   public userRegistered = false;
   //ユーザ登録衛星名

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -110,8 +110,8 @@ export function initializeIpcEvents() {
   /**
    * 衛星IDに一致するデフォルト衛星情報を取得を返す
    */
-  ipcMain.handle("getDefaultSatelliteBySatelliteId", (event, satelliteId: number) => {
-    return new DefaultSatelliteService().getDefaultSatelliteBySatelliteId(satelliteId);
+  ipcMain.handle("getDefaultSatelliteBySatelliteId", (event, satelliteId: number, useAppConfigIfExists: boolean) => {
+    return new DefaultSatelliteService().getDefaultSatelliteBySatelliteId(satelliteId, useAppConfigIfExists);
   });
 
   /**

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -131,8 +131,8 @@ export function initializeIpcEvents() {
   /**
    * 衛星IDに一致するアプリケーション設定かデフォルト衛星情報を取得を返す
    */
-  ipcMain.handle("getUserRegisteredAppConfigSatellite", (event, satelliteId: number) => {
-    return new AppConfigSatelliteService().getUserRegisteredAppConfigSatellite(satelliteId);
+  ipcMain.handle("getUserRegisteredAppConfigSatellite", (event, satelliteId: number, groupdId: number) => {
+    return new AppConfigSatelliteService().getUserRegisteredAppConfigSatellite(satelliteId, groupdId);
   });
 
   /**

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -99,8 +99,11 @@ const apiHandler = {
    * 衛星IDに一致するデフォルト衛星情報を取得を返す
    * 呼び出し例）const ret = await window.rstApi.getDefaultSatelliteBySatelliteId();
    */
-  getDefaultSatelliteBySatelliteId: function (satelliteId: number): Promise<string> {
-    return ipcRenderer.invoke("getDefaultSatelliteBySatelliteId", satelliteId);
+  getDefaultSatelliteBySatelliteId: function (
+    satelliteId: number,
+    useDefaultAppConfigIfExists: boolean
+  ): Promise<string> {
+    return ipcRenderer.invoke("getDefaultSatelliteBySatelliteId", satelliteId, useDefaultAppConfigIfExists);
   },
 
   /**

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -123,8 +123,8 @@ const apiHandler = {
    * 衛星IDに一致するアプリケーション設定かデフォルト衛星情報を取得を返す
    * 呼び出し例）const ret = await window.rstApi.getUserRegisteredAppConfigSatellite(satelliteId);
    */
-  getUserRegisteredAppConfigSatellite: function (satelliteId: number): Promise<AppConfigSatellite> {
-    return ipcRenderer.invoke("getUserRegisteredAppConfigSatellite", satelliteId);
+  getUserRegisteredAppConfigSatellite: function (satelliteId: number, groupdId: number): Promise<AppConfigSatellite> {
+    return ipcRenderer.invoke("getUserRegisteredAppConfigSatellite", satelliteId, groupdId);
   },
 
   /**

--- a/src/main/service/AppConfigSatelliteService.ts
+++ b/src/main/service/AppConfigSatelliteService.ts
@@ -1,3 +1,4 @@
+import Constant from "@/common/Constant";
 import { AppConfigModel, AppConfigSatellite } from "@/common/model/AppConfigModel";
 import DefaultSatelliteService from "@/main/service/DefaultSatelliteService";
 import { AppConfigUtil } from "@/main/util/AppConfigUtil";
@@ -30,13 +31,16 @@ export default class AppConfigSatelliteService {
     const appConfig: AppConfigModel = AppConfigUtil.getConfig();
     if (!appConfig) return appConfigSatellite;
 
+    // デフォルトグループの衛星を探す
     let satellite = appConfig.satellites.find(
+      (sat: AppConfigSatellite) =>
+        sat.satelliteId === satelliteId && sat.groupId === Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID
+    );
+
+    // グループIDが一致する衛星があったら上書き
+    satellite = appConfig.satellites.find(
       (sat: AppConfigSatellite) => sat.satelliteId === satelliteId && sat.groupId === groupId
     );
-    if (!satellite) {
-      // グループIDが一致する衛星がない場合はグループIDを無視して探す
-      satellite = appConfig.satellites.find((sat: AppConfigSatellite) => sat.satelliteId === satelliteId);
-    }
 
     if (satellite) {
       AppConfigUtil.copyMatchingProperties(appConfigSatellite, satellite);

--- a/src/main/service/AppConfigSatelliteService.ts
+++ b/src/main/service/AppConfigSatelliteService.ts
@@ -9,11 +9,12 @@ export default class AppConfigSatelliteService {
   /**
    * 衛星IDでデフォルト衛星情報とアプリケーション設定を検索してデータがあるものを返す
    * @param satelliteId
+   * @param groupId
    * @returns null:一致するデフォルト衛星がない
    *          デフォルト衛星情報:アプリケーション設定がない
    *          アプリケーション設定の衛星:アプリケーション設定がある
    */
-  public getUserRegisteredAppConfigSatellite(satelliteId: number): AppConfigSatellite | null {
+  public getUserRegisteredAppConfigSatellite(satelliteId: number, groupId: number): AppConfigSatellite | null {
     const defSatService: DefaultSatelliteService = new DefaultSatelliteService();
     const defSat = defSatService.getDefaultSatelliteBySatelliteIdSync(satelliteId);
 
@@ -29,7 +30,14 @@ export default class AppConfigSatelliteService {
     const appConfig: AppConfigModel = AppConfigUtil.getConfig();
     if (!appConfig) return appConfigSatellite;
 
-    const satellite = appConfig.satellites.find((sat: AppConfigSatellite) => sat.satelliteId === satelliteId);
+    let satellite = appConfig.satellites.find(
+      (sat: AppConfigSatellite) => sat.satelliteId === satelliteId && sat.groupId === groupId
+    );
+    if (!satellite) {
+      // グループIDが一致する衛星がない場合はグループIDを無視して探す
+      satellite = appConfig.satellites.find((sat: AppConfigSatellite) => sat.satelliteId === satelliteId);
+    }
+
     if (satellite) {
       AppConfigUtil.copyMatchingProperties(appConfigSatellite, satellite);
     }

--- a/src/main/service/AppConfigSatelliteService.ts
+++ b/src/main/service/AppConfigSatelliteService.ts
@@ -1,5 +1,4 @@
-import Constant from "@/common/Constant";
-import { AppConfigModel, AppConfigSatellite } from "@/common/model/AppConfigModel";
+import { AppConfigSatellite } from "@/common/model/AppConfigModel";
 import DefaultSatelliteService from "@/main/service/DefaultSatelliteService";
 import { AppConfigUtil } from "@/main/util/AppConfigUtil";
 
@@ -28,23 +27,11 @@ export default class AppConfigSatelliteService {
     appConfigSatellite.userRegisteredSatelliteName = defSat.satelliteName;
 
     // アプリケーション設定の衛星があれば設定する
-    const appConfig: AppConfigModel = AppConfigUtil.getConfig();
-    if (!appConfig) return appConfigSatellite;
+    const satellite: AppConfigSatellite | null = AppConfigUtil.searchAppConfigSatellite(satelliteId, groupId);
+    if (!satellite) return appConfigSatellite;
 
-    // デフォルトグループの衛星を探す
-    let satellite = appConfig.satellites.find(
-      (sat: AppConfigSatellite) =>
-        sat.satelliteId === satelliteId && sat.groupId === Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID
-    );
+    AppConfigUtil.copyMatchingProperties(appConfigSatellite, satellite);
 
-    // グループIDが一致する衛星があったら上書き
-    satellite = appConfig.satellites.find(
-      (sat: AppConfigSatellite) => sat.satelliteId === satelliteId && sat.groupId === groupId
-    );
-
-    if (satellite) {
-      AppConfigUtil.copyMatchingProperties(appConfigSatellite, satellite);
-    }
     return appConfigSatellite;
   }
 }

--- a/src/main/service/DefaultSatelliteService.ts
+++ b/src/main/service/DefaultSatelliteService.ts
@@ -97,11 +97,11 @@ export default class DefaultSatelliteService {
     satelliteId: number,
     useAppConfigIfExists = true
   ): Promise<DefaultSatelliteType | null> {
-    // デフォルト衛星定義から衛星識別情報を取得
+    // デフォルト衛星定義を取得
 
-    const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    const defSat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
     if (!useAppConfigIfExists) {
-      return defsat;
+      return defSat;
     }
     const appDefSat = AppConfigUtil.searchAppConfigSatellite(
       satelliteId,
@@ -109,13 +109,14 @@ export default class DefaultSatelliteService {
     );
 
     // 編集したデフォルト衛星定義がある場合は上書き
-    if (appDefSat && defsat) {
-      AppConfigUtil.copyMatchingProperties(defsat, appDefSat);
-      defsat.satelliteName = appDefSat.userRegisteredSatelliteName;
+    if (appDefSat && defSat) {
+      AppConfigUtil.copyMatchingProperties(defSat, appDefSat);
+      defSat.satelliteName = appDefSat.userRegisteredSatelliteName;
     }
 
-    return defsat;
+    return defSat;
   }
+
   /**
    * 衛星IDに一致するデフォルト衛星を取得(同期)
    * @param satelliteId
@@ -126,11 +127,11 @@ export default class DefaultSatelliteService {
     satelliteId: number,
     useAppConfigIfExists = true
   ): DefaultSatelliteType | null {
-    // デフォルト衛星定義から衛星識別情報を取得
+    // デフォルト衛星定義を取得
 
-    const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    const defSat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
     if (!useAppConfigIfExists) {
-      return defsat;
+      return defSat;
     }
 
     const appDefSat = AppConfigUtil.searchAppConfigSatellite(
@@ -139,11 +140,11 @@ export default class DefaultSatelliteService {
     );
 
     // 編集したデフォルト衛星定義がある場合は上書き
-    if (appDefSat && defsat) {
-      AppConfigUtil.copyMatchingProperties(defsat, appDefSat);
-      defsat.satelliteName = appDefSat.userRegisteredSatelliteName;
+    if (appDefSat && defSat) {
+      AppConfigUtil.copyMatchingProperties(defSat, appDefSat);
+      defSat.satelliteName = appDefSat.userRegisteredSatelliteName;
     }
-    return defsat;
+    return defSat;
   }
 
   /**

--- a/src/main/service/DefaultSatelliteService.ts
+++ b/src/main/service/DefaultSatelliteService.ts
@@ -90,12 +90,19 @@ export default class DefaultSatelliteService {
   /**
    * 衛星IDに一致するデフォルト衛星を取得
    * @param satelliteId
+   * @param useAppConfigIfExists true:アプリケーション設定にデフォルト設定があれば使用する/false:アプリケーション設定を無視してデフォルト衛星情報を取得する
    * @returns
    */
-  public async getDefaultSatelliteBySatelliteId(satelliteId: number): Promise<DefaultSatelliteType | null> {
+  public async getDefaultSatelliteBySatelliteId(
+    satelliteId: number,
+    useAppConfigIfExists = true
+  ): Promise<DefaultSatelliteType | null> {
     // デフォルト衛星定義から衛星識別情報を取得
 
     const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    if (!useAppConfigIfExists) {
+      return defsat;
+    }
     const appDefSat = AppConfigUtil.searchAppConfigSatellite(
       satelliteId,
       Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID
@@ -112,12 +119,20 @@ export default class DefaultSatelliteService {
   /**
    * 衛星IDに一致するデフォルト衛星を取得(同期)
    * @param satelliteId
+   * @param useAppConfigIfExists true:アプリケーション設定にデフォルト設定があれば使用する/false:アプリケーション設定を無視してデフォルト衛星情報を取得する
    * @returns
    */
-  public getDefaultSatelliteBySatelliteIdSync(satelliteId: number): DefaultSatelliteType | null {
+  public getDefaultSatelliteBySatelliteIdSync(
+    satelliteId: number,
+    useAppConfigIfExists = true
+  ): DefaultSatelliteType | null {
     // デフォルト衛星定義から衛星識別情報を取得
 
     const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    if (!useAppConfigIfExists) {
+      return defsat;
+    }
+
     const appDefSat = AppConfigUtil.searchAppConfigSatellite(
       satelliteId,
       Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID

--- a/src/main/service/DefaultSatelliteService.ts
+++ b/src/main/service/DefaultSatelliteService.ts
@@ -88,26 +88,47 @@ export default class DefaultSatelliteService {
   }
 
   /**
-   * 衛星IDに一致する衛星識別情報を取得
+   * 衛星IDに一致するデフォルト衛星を取得
    * @param satelliteId
    * @returns
    */
   public async getDefaultSatelliteBySatelliteId(satelliteId: number): Promise<DefaultSatelliteType | null> {
     // デフォルト衛星定義から衛星識別情報を取得
 
-    const satIdentifer: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
-    return satIdentifer;
+    const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    const appDefSat = AppConfigUtil.searchAppConfigSatellite(
+      satelliteId,
+      Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID
+    );
+
+    // 編集したデフォルト衛星定義がある場合は上書き
+    if (appDefSat && defsat) {
+      AppConfigUtil.copyMatchingProperties(defsat, appDefSat);
+      defsat.satelliteName = appDefSat.userRegisteredSatelliteName;
+    }
+
+    return defsat;
   }
   /**
-   * 衛星IDに一致する衛星識別情報を取得(同期)
+   * 衛星IDに一致するデフォルト衛星を取得(同期)
    * @param satelliteId
    * @returns
    */
   public getDefaultSatelliteBySatelliteIdSync(satelliteId: number): DefaultSatelliteType | null {
     // デフォルト衛星定義から衛星識別情報を取得
 
-    const satIdentifer: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
-    return satIdentifer;
+    const defsat: DefaultSatelliteType | null = this.defSatJson.getDefaultSatelliteBySatelliteId(satelliteId);
+    const appDefSat = AppConfigUtil.searchAppConfigSatellite(
+      satelliteId,
+      Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID
+    );
+
+    // 編集したデフォルト衛星定義がある場合は上書き
+    if (appDefSat && defsat) {
+      AppConfigUtil.copyMatchingProperties(defsat, appDefSat);
+      defsat.satelliteName = appDefSat.userRegisteredSatelliteName;
+    }
+    return defsat;
   }
 
   /**

--- a/src/main/util/AppConfigUtil.ts
+++ b/src/main/util/AppConfigUtil.ts
@@ -1,5 +1,10 @@
 import Constant from "@/common/Constant";
-import { AppConfigMainDisplay, AppConfigModel, AppConfigSatelliteGroup } from "@/common/model/AppConfigModel";
+import {
+  AppConfigMainDisplay,
+  AppConfigModel,
+  AppConfigSatellite,
+  AppConfigSatelliteGroup,
+} from "@/common/model/AppConfigModel";
 import { AppConfigRotatorDevice, AppConfigRotatorModel } from "@/common/model/AppConfigRotatorModel";
 import { AppConfigSatSettingModel } from "@/common/model/AppConfigSatelliteSettingModel";
 import { AppConfigTransceiverDevice, AppConfigTransceiverModel } from "@/common/model/AppConfigTransceiverModel";
@@ -455,5 +460,17 @@ export class AppConfigUtil {
         (target as any)[key] = (source as any)[key]; // 型安全のため `any` を使用
       }
     });
+  }
+
+  /**
+   * アプリケーション設定の衛星を検索する
+   * @param satelliteId
+   * @param groupdId
+   * @returns 見つからなければnull
+   */
+  public static searchAppConfigSatellite(satelliteId: number, groupdId: number): AppConfigSatellite | null {
+    const appConfigSats = this.getConfig().satellites;
+    if (appConfigSats.length === 0) return null;
+    return appConfigSats.find((sat) => sat.satelliteId === satelliteId && sat.groupId === groupdId) ?? null;
   }
 }

--- a/src/main/util/AppConfigUtil.ts
+++ b/src/main/util/AppConfigUtil.ts
@@ -399,7 +399,7 @@ export class AppConfigUtil {
       const satIdentifers = groups.satelliteIds
         .map((satelliteId) => {
           // 衛星IDから該当する衛星デフォルト情報を取得する
-          const appConfigSat = appConfSatService.getUserRegisteredAppConfigSatellite(satelliteId);
+          const appConfigSat = appConfSatService.getUserRegisteredAppConfigSatellite(satelliteId, groups.groupId);
           // 返却に必要な衛星IDと衛星名の組み合わせにする
           if (appConfigSat === null) {
             // ないはずだが衛星IDがヒットしなければundefined

--- a/src/renderer/api/ApiAppConfigSatellite.ts
+++ b/src/renderer/api/ApiAppConfigSatellite.ts
@@ -8,14 +8,17 @@ export default class ApiAppConfigSatellite {
    * アプリケーション設定の衛星かデフォルト衛星情報を返す
    * @returns
    */
-  public static async getUserRegisteredAppConfigSatellite(satelliteId: number): Promise<AppConfigSatellite> {
-    return await window.rstApi.getUserRegisteredAppConfigSatellite(satelliteId);
+  public static async getUserRegisteredAppConfigSatellite(
+    satelliteId: number,
+    groupId: number
+  ): Promise<AppConfigSatellite> {
+    return await window.rstApi.getUserRegisteredAppConfigSatellite(satelliteId, groupId);
   }
   /**
    * アプリケーション設定の衛星を取得する
    */
-  public static async getAppConfigSatellite(satelliteId: number): Promise<AppConfigSatellite | null> {
+  public static async getAppConfigSatellite(satelliteId: number, groupdId: number): Promise<AppConfigSatellite | null> {
     const appConfig: AppConfigModel = await window.rstApi.getAppConfig();
-    return appConfig.satellites.find((sat) => sat.satelliteId === satelliteId) ?? null;
+    return appConfig.satellites.find((sat) => sat.satelliteId === satelliteId && sat.groupId === groupdId) ?? null;
   }
 }

--- a/src/renderer/api/ApiDefaultSatellite.ts
+++ b/src/renderer/api/ApiDefaultSatellite.ts
@@ -13,10 +13,15 @@ export default class ApiDefaultSatellite {
   }
   /**
    * 衛星IDに一致するデフォルト衛星情報を取得を返す
+   * @param {number} satelliteId 衛星ID
+   * @param {boolean} useDefaultAppConfigIfExists true:アプリケーション設定にデフォルト設定があれば使用する/false:アプリケーション設定を無視してデフォルト衛星情報を取得する
    * @returns {Promise<DefaultSatelliteType>} TLE文字列
    */
-  public static async getDefaultSatelliteBySatelliteId(satelliteId: number): Promise<DefaultSatelliteType> {
-    return await window.rstApi.getDefaultSatelliteBySatelliteId(satelliteId);
+  public static async getDefaultSatelliteBySatelliteId(
+    satelliteId: number,
+    useDefaultAppConfigIfExists = true
+  ): Promise<DefaultSatelliteType> {
+    return await window.rstApi.getDefaultSatelliteBySatelliteId(satelliteId, useDefaultAppConfigIfExists);
   }
 
   /**

--- a/src/renderer/common/util/ActiveSatHelper.ts
+++ b/src/renderer/common/util/ActiveSatHelper.ts
@@ -30,7 +30,10 @@ export default class ActiveSatHelper {
     const sats: ActiveSatelliteModel[] = [];
     for (let ii = 0; ii < gr.satelliteIds.length; ii++) {
       const satId = gr.satelliteIds[ii];
-      const sat: AppConfigSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(satId);
+      const sat: AppConfigSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(
+        satId,
+        gr.groupId
+      );
 
       const satModel = new ActiveSatelliteModel();
       satModel.satelliteId = satId;

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -427,7 +427,8 @@ async function onCancel() {
 async function onReset() {
   // デフォルト衛星情報を取得
   const defsat: DefaultSatelliteType = await ApiDefaultSatellite.getDefaultSatelliteBySatelliteId(
-    selectedItem.value.satelliteId
+    selectedItem.value.satelliteId,
+    false
   );
   if (defsat) {
     transformDefSatToForm(form.value, defsat);

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -304,6 +304,10 @@ const isShow = defineModel<boolean>("isShow", {
 const selectedItem = defineModel<SatelliteIdentiferType>("selectedItem", {
   default: {},
 });
+// 衛星追加用の親のグループ
+const selectedGroupId = defineModel<number>("selectedGroupId", {
+  default: Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID,
+});
 // 親に通知用のイベント
 const emits = defineEmits<{ (e: "onOk"): void; (e: "onCancel"): void }>();
 // 画面を使って設定をしたかどうか
@@ -323,10 +327,14 @@ const { transformAppConfigToForm, transformDefSatToForm, transformFormToAppConfi
 onMounted(async function () {
   // 衛星を取得
   const registedSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(
-    selectedItem.value.satelliteId
+    selectedItem.value.satelliteId,
+    selectedGroupId.value
   );
   // ユーザ登録されているか確認する
-  const appConfigSatellite = await ApiAppConfigSatellite.getAppConfigSatellite(selectedItem.value.satelliteId);
+  const appConfigSatellite = await ApiAppConfigSatellite.getAppConfigSatellite(
+    selectedItem.value.satelliteId,
+    selectedGroupId.value
+  );
 
   // 画面に設定する
   transformAppConfigToForm(form.value, registedSatellite);
@@ -367,11 +375,12 @@ async function onOk() {
     return;
   }
 
+  // データ削除をするのであえてindexで処理する
   const appConfig = await ApiAppConfig.getAppConfig();
   const formSatId = form.value.satelliteId;
 
   const index = appConfig.satellites.findIndex((sat) => {
-    return sat.satelliteId === formSatId;
+    return sat.satelliteId === formSatId && sat.groupId === selectedGroupId.value;
   });
 
   if (index > -1) {
@@ -381,6 +390,7 @@ async function onOk() {
     if (manualEditFlg.value) {
       const sat: AppConfigSatellite = appConfig.satellites[index];
       transformFormToAppConfig(sat, form.value);
+      sat.groupId = selectedGroupId.value;
     } else {
       appConfig.satellites.splice(index, 1);
     }
@@ -388,6 +398,7 @@ async function onOk() {
     // アプリケーション設定になければ新規追加
     const sat: AppConfigSatellite = new AppConfigSatellite();
     transformFormToAppConfig(sat, form.value);
+    sat.groupId = selectedGroupId.value;
     appConfig.satellites.push(sat);
   }
 
@@ -428,4 +439,3 @@ async function onReset() {
 <style lang="scss" scoped>
 @import "./EditSatelliteInfo.scss";
 </style>
-

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -387,8 +387,9 @@ async function onOk() {
     // アプリケーション設定にあった場合
     // リセットを押してなければ(マニュアル設定がON)更新する
     // リセットを押していたら(マニュアル設定がOFF)削除する
-    if (manualEditFlg.value) {
-      const sat: AppConfigSatellite = appConfig.satellites[index];
+    // 手動登録衛星の場合はsatellitesにTLEの情報とかがあるので更新とする
+    const sat: AppConfigSatellite = appConfig.satellites[index];
+    if (manualEditFlg.value || sat.userRegistered) {
       transformFormToAppConfig(sat, form.value);
       sat.groupId = selectedGroupId.value;
     } else {

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
@@ -183,7 +183,9 @@ const selectedSatelliteItem = defineModel<SatelliteIdentiferType>("selectedSatel
   default: { satelliteId: -1, satelliteName: "" },
 });
 // 衛星追加用の親のグループ
-const selectedGroup = defineModel("selectedGroup");
+const selectedGroupId = defineModel<number>("selectedGroupId", {
+  default: Constant.SatSetting.DEFAULT_SATELLITE_GROUP_ID,
+});
 // 衛星追加用の親の衛星リスト
 const selectedSatellites = defineModel<SatelliteIdentiferType[]>("selectedSatellites", { default: [] });
 // 親に通知用のイベント
@@ -199,7 +201,8 @@ onMounted(async function () {
   if (selectedSatelliteItem.value.satelliteId > -1) {
     // ユーザ登録されている情報を探す
     const registedSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(
-      selectedSatelliteItem.value.satelliteId
+      selectedSatelliteItem.value.satelliteId,
+      selectedGroupId.value
     );
     // 画面反映
     setForm(form.value, registedSatellite);
@@ -236,7 +239,7 @@ async function onOk() {
   // 取得
   const appConfig = await ApiAppConfig.getAppConfig();
   // 画面情報を反映
-  const isNewItem = await setAppConfig(appConfig, form.value);
+  const isNewItem = await setAppConfig(appConfig, form.value, selectedGroupId.value);
 
   if (isNewItem) {
     // 追加した場合はリストの一番後ろが追加した衛星
@@ -244,7 +247,7 @@ async function onOk() {
     // ここでないなんてことないのだけどエラーが出るので存在確認しておく
     if (apiSat) {
       // 登録した衛星が消えないようにグループに登録しておく
-      const group = appConfig.satelliteGroups.find((gp) => gp.groupName === selectedGroup.value);
+      const group = appConfig.satelliteGroups.find((gp) => gp.groupId === selectedGroupId.value);
       group?.satelliteIds.push(apiSat.satelliteId);
       // 親のリストに追加
       selectedSatellites.value.push({

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteUtils.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteUtils.ts
@@ -53,6 +53,7 @@ export async function setAppConfig(
 
   // 画面入力項目を反映
   apiSat.userRegistered = true;
+  apiSat.groupId = groupdId;
   apiSat.userRegisteredSatelliteName = srcFrom.satelliteName;
   // TLE入力の場合は軌道6要素が入っててもTLEを優先する
   let tle = srcFrom.tle;

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteUtils.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteUtils.ts
@@ -36,7 +36,11 @@ export function setForm(targetForm: RegistSatelliteForm, srcObject: AppConfigSat
  * @param srcFrom
  * @returns
  */
-export async function setAppConfig(targetAppConfig: AppConfigModel, srcFrom: RegistSatelliteForm): Promise<boolean> {
+export async function setAppConfig(
+  targetAppConfig: AppConfigModel,
+  srcFrom: RegistSatelliteForm,
+  groupdId: number
+): Promise<boolean> {
   // 新規追加フラグ
   const isNewItem = srcFrom.satelliteId === -1;
   // 衛星ID
@@ -45,7 +49,7 @@ export async function setAppConfig(targetAppConfig: AppConfigModel, srcFrom: Reg
     // 新規の場合衛星IDを採番
     satelliteId = await ApiDefaultSatellite.addDefaultSatellite(srcFrom.satelliteName);
   }
-  const apiSat = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(satelliteId);
+  const apiSat = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(satelliteId, groupdId);
 
   // 画面入力項目を反映
   apiSat.userRegistered = true;
@@ -82,7 +86,7 @@ export async function setAppConfig(targetAppConfig: AppConfigModel, srcFrom: Reg
   } else {
     // 更新の場合、衛星設定を反映する
     targetAppConfig.satellites.forEach((sat) => {
-      if (sat.satelliteId === apiSat.satelliteId) {
+      if (sat.satelliteId === apiSat.satelliteId && sat.groupId === groupdId) {
         Object.assign(sat, apiSat);
       }
     });

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/SelectControlledItemList/SelectControlledItemList.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/SelectControlledItemList/SelectControlledItemList.vue
@@ -67,7 +67,7 @@
               v-if="enableRegistSatellite"
               :isShow="enableRegistSatellite"
               :selectedSatelliteItem="selectedSatelliteItem"
-              :selectedGroup="selectedGroup.groupId"
+              :selectedGroupId="selectedGroup.groupId"
               :selectedSatellites="selectedSatellites"
               @onOk="onCloseRegistSatellite"
               @onCancel="onCloseRegistSatellite"

--- a/src/renderer/service/ActiveSatServiceHub.ts
+++ b/src/renderer/service/ActiveSatServiceHub.ts
@@ -221,7 +221,10 @@ export default class ActiveSatServiceHub {
       return 0;
     }
 
-    const appConfigSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(satGrp.mainSatelliteId);
+    const appConfigSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(
+      satGrp.mainSatelliteId,
+      satGrp.activeSatelliteGroupId
+    );
     if (appConfigSatellite) {
       // アクティブ衛星のアップリンク設定
       switch (appConfigSatellite.autoModeUplinkFreq) {


### PR DESCRIPTION
# 前提
- 衛星の周波数等の情報は衛星IDを起点にするため別グループに衛星を登録しても中のデータは共有されていた
- そのためAグループで設定した内容が、Bグループで同じ衛星を開くと同じ値が入っていて個別に設定できなかった
# 実装概要
- 衛星情報の管理は衛星IDとグループIDで一意になるようにした
  - アプリケーション設定の衛星情報を検索する際は衛星IDとグループIDを使って検索する
- アプリケーション設定のsatellitesの中でモデルにgroupIdを追加した
  - groupdIdは衛星を追加したグループのIDを設定する
  - グループに所属しない衛星を編集した場合は-1を設定する（グループ追加前の衛星を編集した場合に相当）
<img width="1202" height="1472" alt="image" src="https://github.com/user-attachments/assets/558ebe17-2cc5-4c68-89b0-8926a31b7e5f" />
<img width="1192" height="1482" alt="image" src="https://github.com/user-attachments/assets/aa4f937d-e900-446d-b42d-2d8479144a3f" />

# 注意点
- satellitesにgroupdIdがないバージョンからバージョンアップした場合は、satellitesのデータはgroupdId=-1として扱う
  - 各グループから衛星を編集する場合、初回表示では同じデータに見えるが、登録をすると別グループのデータとして区別して保存される

# 関連
- なし