### PR TITLE
UTエラー対応／ひまわり8号のTLEの内容によってUTが失敗する件の対応

### DIFF
--- a/src/__tests__/renderer/service/OverlapPassesService.test.ts
+++ b/src/__tests__/renderer/service/OverlapPassesService.test.ts
@@ -28,26 +28,28 @@ describe("[正常系]2か所の地上局から観測できる人工衛星の可�
     expect(issResult && issResult[0].durationMs).not.toBe(null);
   });
 
-  it("2か所の地上局から常に可視の人工衛星の可視時間リストが取得できる", async () => {
-    const nowDate = new Date("2025-09-06T00:00:00Z");
-    const oneDayLaterDate = new Date(nowDate.getTime() + 24 * 60 * 60 * 1000);
+  // MEMO: TLEをもとに計算した衛星軌道は長時間が経過すると、赤道面に対して横移動してしまうため？以下ケースはテストが失敗する。
+  //       最新のTLEを使用することでテストは成功するが、UTでの動的データの取得は避けるため、コメントアウトしている。
+  // it("2か所の地上局から常に可視の人工衛星の可視時間リストが取得できる", async () => {
+  //   const nowDate = new Date("2025-09-06T00:00:00Z");
+  //   const oneDayLaterDate = new Date(nowDate.getTime() + 24 * 60 * 60 * 1000);
 
-    // 宮本工場(東京都江戸川区)と種子島宇宙センターで常に可視の人工衛星の可視時間リストが取得できる
-    const himawariOverlapPasses = new OverlapPassesService(
-      TleDataHelper.Satellite.HIMAWARI8_20250906,
-      GROUND_STATION.latitudeDeg,
-      GROUND_STATION.longitudeDeg,
-      GROUND2_STATION.latitudeDeg,
-      GROUND2_STATION.longitudeDeg,
-      GROUND_STATION.AltitudeM,
-      GROUND2_STATION.AltitudeM
-    );
-    const himawariResult = await himawariOverlapPasses.getOverlapPassesListAsync(nowDate, oneDayLaterDate);
-    expect(himawariResult && himawariResult[0].aos).toBe(null);
-    expect(himawariResult && himawariResult[0].maxEl).not.toBe(null);
-    expect(himawariResult && himawariResult[0].los).toBe(null);
-    expect(himawariResult && himawariResult[0].durationMs).toBe(null);
-  });
+  //   // 宮本工場(東京都江戸川区)と種子島宇宙センターで常に可視の人工衛星の可視時間リストが取得できる
+  //   const himawariOverlapPasses = new OverlapPassesService(
+  //     TleDataHelper.Satellite.HIMAWARI8_20250906,
+  //     GROUND_STATION.latitudeDeg,
+  //     GROUND_STATION.longitudeDeg,
+  //     GROUND2_STATION.latitudeDeg,
+  //     GROUND2_STATION.longitudeDeg,
+  //     GROUND_STATION.AltitudeM,
+  //     GROUND2_STATION.AltitudeM
+  //   );
+  //   const himawariResult = await himawariOverlapPasses.getOverlapPassesListAsync(nowDate, oneDayLaterDate);
+  //   expect(himawariResult && himawariResult[0].aos).toBe(null);
+  //   expect(himawariResult && himawariResult[0].maxEl).not.toBe(null);
+  //   expect(himawariResult && himawariResult[0].los).toBe(null);
+  //   expect(himawariResult && himawariResult[0].durationMs).toBe(null);
+  // });
 });
 
 /**


### PR DESCRIPTION
"2か所の地上局から常に可視の人工衛星の可視時間リストが取得できる"ケースにおいて、古いTLEの利用によりテストが失敗する。
当該箇所をコメントして回避。

以下、 @stargazer1846923 のコメント。
- 軌道計算ロジックに誤りはなく、テスト用TLEデータが古いことが原因
- TLEをもとに計算した衛星軌道は長時間が経過すると、赤道面に対して横移動してしまうようです。）
- RSTでの運用時は都度最新のTLEを利用するのと、すでに軌道計算ロジックは機能として完成しているため、テストコードを一旦コメントアウトする対応で良いかと思います。
