### PR TITLE
軌道六要素側でもEpochが古いのを許容する

### DIFF
--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -87,7 +87,7 @@ export default class I18nMsgs {
   };
   public static readonly CHK_ERR_EXPIRED_TLE: I18nMsgItem = {
     en: "The TLE epoch is out of date and may not provide accurate orbit estimation. Is this OK?",
-    ja: "TLEのepochが古いため正確な軌道推定ができない可能性があります。よろしいですか？",
+    ja: "epochが古いため正確な軌道推定ができない可能性があります。よろしいですか？",
   };
   public static readonly CHK_ERR_ALL_ORBIT: I18nMsgItem = {
     en: "Please enter all 6 Orbital Elements",

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
@@ -228,8 +228,8 @@ async function onOk() {
     // キャンセルが押下されたら終了
     if (!isOk) return;
   }
-  // TLEが有効期限切れの場合は確認
-  if (errors.value["tleEpoch"]) {
+  // Epochが有効期限切れの場合は確認
+  if (errors.value["tleEpoch"] || errors.value["epochUtcDate"]) {
     const isOk = await showConfirm(I18nUtil.getMsg(I18nMsgs.CHK_ERR_EXPIRED_TLE));
 
     // キャンセルが押下されたら終了

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteValidate.ts
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/useRegistSatelliteValidate.ts
@@ -47,7 +47,7 @@ export function useRegistSatelliteValidate() {
     // 軌道6要素が入力されている場合のチェック
     if (!form.tle && form.epochUtcDate && !validateOrbitalEpoch(form.epochUtcDate)) {
       errors.value["epochUtcDate"] = I18nUtil.getMsg(I18nMsgs.CHK_ERR_DATE_RANGE);
-      return false;
+      // 確認とするためfalseにしない
     }
 
     // TLEが入力されている場合のチェック


### PR DESCRIPTION
# 前提
- TLE側ではEpochが古いことを許容していたが軌道六要素側ではエラーとしていた

# 実装概要
- 軌道六要素側でもEpochが古いことは許容するようにした
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/082ad2de-d51d-4a4e-a496-666e534f3b61" />

# 注意点
- なし
# 関連
- なし