### PR TITLE
現在時刻でローテータ自動追尾した場合にLOS後の追尾継続が行われないバグ対応

### DIFF
--- a/src/renderer/components/organisms/Aos/Aos.vue
+++ b/src/renderer/components/organisms/Aos/Aos.vue
@@ -1,3 +1,4 @@
+<!-- AOS/LOSまでのカウントダウン表示 -->
 <template>
   <BoxLabel v-if="overlapPassCountdown" class="aos">{{ CanvasUtil.formatNullValue(overlapPassCountdown) }}</BoxLabel>
   <BoxLabel v-else class="aos">{{ CanvasUtil.formatNullValue(passCountdown) }}</BoxLabel>

--- a/src/renderer/service/GroundStationService.ts
+++ b/src/renderer/service/GroundStationService.ts
@@ -279,7 +279,9 @@ class GroundStationService {
 
     // 現在日時からN分前の時刻を判定用の現在時刻とする
     // memo: LOS後のローテータ、無線機の継続追尾を可能とするため、現在時刻が過ぎたパスも処理対象に含める必要がある
-    const startOffsetDate = new Date(currentDate.getTime() - CURRENT_DATE_OFFSET_MINUTES * 60 * 1000);
+    const startOffsetDate = new Date(
+      currentDate.getTime() - CURRENT_DATE_OFFSET_MINUTES * Constant.Time.MILLISECONDS_IN_MINUTE
+    );
 
     // AOS/LOS/Melの一時キャッシュ配列を初期化する
     let tempPassesCache: PassesCache[] = [];
@@ -324,8 +326,6 @@ class GroundStationService {
         // 日時期間(開始)が計算済み終端時間より新しい場合は、計算済み終端時間から日時期間(開始)を未探索日時区間配列に追加する
         this._addUnexploredTime(this._calculatedTime, targetStartDate.getTime());
       }
-      // 日時期間(開始)以降のパスを取得する
-      tempPassesCache = [...this._passesCache].filter((cache) => cache.los && cache.los.date >= targetStartDate);
 
       if (endDate) {
         // 日時期間(開始)から日時期間(終了)までのパスを取得する場合


### PR DESCRIPTION
現在時刻でローテータ自動追尾した場合にLOS後の追尾継続が行われないバグ対応。

■不具合内容
- LOG直後にローテータがパークポジションに設定されてしまう。

■正常な挙動
- ローテータ自動追尾（Auto）をOnにする。
- ローテータ設定画面の継続追尾時間をゼロ分以外（1分など）に設定する。
- LOSを過ぎても、継続追尾時間までは追尾が行われる。
- 継続追尾時間が過ぎた場合、ローテータはパークポジションに設定される。

■再現方法
- メイン画面右下の時刻設定をゼロ（現在日時）とする。
- ローテータ設定画面の継続追尾時間をゼロ分以外（1分など）に設定する。
- ローテータ自動追尾（Auto）をOnにする。
- LOSを過ぎるとローテータがパークポジションに設定されてしまう。
- （継続追尾時間まで追尾が継続されない）

■原因
- メイン画面右下の時刻設定がゼロ（現在日時）の場合に発生する。
- 衛星パスの算出において、現在時刻より過去のパスは除外されていたため、LOS直後のパスが取得できない。
- 現在のパスとして扱っていたパスが次パスとなってしまい、LOS後の継続時刻も次パスで算出されていたため、LOS後の継続追尾時刻の算出が出来ていなかった。
- メイン画面右下の時刻設定にて未来日時を設定している場合は、パスは未来時刻となるため、現在時刻に対する対象パスは未来時刻となるため、本バグは発生しない。

■対応
- 衛星パスの算出において、パスの計算開始日時を現在日時から１時間前（定数）までを含める。
- これにより、現在日時から過去１時間前までのパスの取得が可能となる。
- ※衛星パスの算出において、過去日時のパスを取得していなかった理由は、過去パスは実際に追尾することが想定されないため。またどこまで過去に遡るか？そもそも軌道に存在しない場合もあるため。
- 過去パスも取得可能とすることで、LOS直後のパスによる追尾が可能となった。
