### PR TITLE
多重起動の防止

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,14 +30,6 @@ let mainWindow: BrowserWindow;
     app.quit();
     return;
   }
-  // 起動中に他のインスタンスが起動した場合
-  app.on("second-instance", () => {
-    if (mainWindow) {
-      AppMainLogger.info("Second instance detected, focusing main window.");
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
-  });
 
   // active化を待つ
   await app.whenReady();
@@ -95,6 +87,14 @@ app.on("window-all-closed", () => {
 
   if (process.platform !== "darwin") {
     app.quit();
+  }
+});
+// 多重起動は防止されているが他のインスタンス起動を検知したらメインウィンドウをフォーカスする
+app.on("second-instance", () => {
+  if (mainWindow) {
+    AppMainLogger.info("Second instance detected, focusing main window.");
+    if (mainWindow.isMinimized()) mainWindow.restore();
+    mainWindow.focus();
   }
 });
 


### PR DESCRIPTION
# 前提
- アプリが多重起動できてしまう

# 実装概要
- 起動済みのインスタンスAと、後から起動するインスタンスBがあるとする
  - インスタンスBが起動時に他のインスタンス(A)が存在していたらインスタンスBの起動を停止するようにした
  - インスタンスA側で他のインスタンス(B)の起動を検知したらインスタンスA側の画面を前面に表示するようにした

# 注意点
- MASビルド(Mac App Storeで公開)の場合はrequestSingleInstanceLockが常にfalseを返すという問題がある
- しかしこれには対処していない
- 現在、Mac版のバイナリは配布しないので問題にはならないが、今後Mac App Storeで公開する場合は修正が必要

# 関連
- なし