### PR TITLE
IC-9700のTONE設定

### DIFF
--- a/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
+++ b/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
@@ -1,0 +1,26 @@
+import TransceiverIcomCmdMaker from "@/main/service/transceiver/controller/TransceiverIcomCmdMaker";
+
+describe("TransceiverIcomCmdMaker.geneToneHzStrのテスト", () => {
+  beforeAll(() => {});
+
+  it("小数点なしの周波数の場合は３桁＋'0'の文字列を返す", () => {
+    const maker = new TransceiverIcomCmdMaker(0x99, "DMY-IC-9700");
+    expect(maker["geneToneHzStr"](1)).toBe("000010");
+    expect(maker["geneToneHzStr"](12)).toBe("000120");
+    expect(maker["geneToneHzStr"](123)).toBe("001230");
+    expect(maker["geneToneHzStr"](999)).toBe("009990");
+  });
+
+  it("小数点付きの周波数の場合は３桁＋１桁の文字列を返す", () => {
+    const maker = new TransceiverIcomCmdMaker(0x99, "DMY-IC-9700");
+    expect(maker["geneToneHzStr"](1.2)).toBe("000012");
+    expect(maker["geneToneHzStr"](12.3)).toBe("000123");
+    expect(maker["geneToneHzStr"](123.4)).toBe("001234");
+    expect(maker["geneToneHzStr"](999.9)).toBe("009999");
+  });
+
+  it("桁あふれの場合は例外が送出される", () => {
+    const maker = new TransceiverIcomCmdMaker(0x99, "DMY-IC-9700");
+    expect(() => maker["geneToneHzStr"](1000)).toThrow("toneHzは999.9以下の値を指定してください。");
+  });
+});

--- a/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
+++ b/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
@@ -1,8 +1,6 @@
 import TransceiverIcomCmdMaker from "@/main/service/transceiver/controller/TransceiverIcomCmdMaker";
 
 describe("TransceiverIcomCmdMaker.geneToneHzStrのテスト", () => {
-  beforeAll(() => {});
-
   it("小数点なしの周波数の場合は３桁＋'0'の文字列を返す", () => {
     const maker = new TransceiverIcomCmdMaker(0x99, "DMY-IC-9700");
     expect(maker["geneToneHzStr"](1)).toBe("000010");

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -224,11 +224,18 @@ export function initializeIpcEvents() {
    * 無線機関係・無線機関係・AutoOn時の初期処理
    */
   ipcMain.handle(
-    "initAutoOn",
+    "transceiverInitAutoOn",
     async (event, txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string, toneHz: number | null) => {
       return await TransceiverService.getInstance().initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
     }
   );
+
+  /**
+   * 無線機関係・無線機関係・AutoOff
+   */
+  ipcMain.handle("transceiverAutoOff", async (event) => {
+    return await TransceiverService.getInstance().autoOff();
+  });
 
   /**
    * 無線機関係・無線機周波数を変更する
@@ -315,9 +322,19 @@ export function releaseIpcEvents() {
   ipcMain.removeAllListeners("addDefaultSatellite");
   ipcMain.removeAllListeners("reCreateDefaultSatellite");
   ipcMain.removeAllListeners("getUserRegisteredAppConfigSatellite");
+  ipcMain.removeAllListeners("startAntennaCtrl");
+  ipcMain.removeAllListeners("stopAntennaCtrl");
   ipcMain.removeAllListeners("setAntennaPosition");
   ipcMain.removeAllListeners("onChangeAntennaPosition");
   ipcMain.removeAllListeners("onRoratorDisconnect");
+  ipcMain.removeAllListeners("getActiveSerialPorts");
+  ipcMain.removeAllListeners("openSerialPortTry");
+  ipcMain.removeAllListeners("closeSerialPort");
+  ipcMain.removeAllListeners("onDispLangChange");
+  ipcMain.removeAllListeners("startTransceiverCtrl");
+  ipcMain.removeAllListeners("stopTransceiverCtrl");
+  ipcMain.removeAllListeners("transceiverInitAutoOn");
+  ipcMain.removeAllListeners("transceiverAutoOff");
   ipcMain.removeAllListeners("getActiveSatelliteGroup");
   ipcMain.removeAllListeners("refreshAppConfig");
   ipcMain.removeAllListeners("setTransceiverFrequency");

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -223,9 +223,12 @@ export function initializeIpcEvents() {
   /**
    * 無線機関係・無線機関係・AutoOn時の初期処理
    */
-  ipcMain.handle("initAutoOn", async (event, txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string) => {
-    return await TransceiverService.getInstance().initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode);
-  });
+  ipcMain.handle(
+    "initAutoOn",
+    async (event, txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string, toneHz: number | null) => {
+      return await TransceiverService.getInstance().initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
+    }
+  );
 
   /**
    * 無線機関係・無線機周波数を変更する

--- a/src/main/initializeIpcEvent.ts
+++ b/src/main/initializeIpcEvent.ts
@@ -221,7 +221,7 @@ export function initializeIpcEvents() {
   });
 
   /**
-   * 無線機関係・無線機関係・AutoOn時の初期処理
+   * 無線機関係・AutoOn時の初期処理
    */
   ipcMain.handle(
     "transceiverInitAutoOn",
@@ -231,7 +231,7 @@ export function initializeIpcEvents() {
   );
 
   /**
-   * 無線機関係・無線機関係・AutoOff
+   * 無線機関係・AutoOff
    */
   ipcMain.handle("transceiverAutoOff", async (event) => {
     return await TransceiverService.getInstance().autoOff();

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -204,16 +204,22 @@ const apiHandler = {
   /**
    * 無線機関係・AutoOn時の初期処理
    */
-  initAutoOn: function (
+  transceiverInitAutoOn: function (
     txFreqHz: number,
     rxFreqHz: number,
     txMode: string,
     rxMode: string,
     toneHz: number | null
   ): Promise<ApiResponse<void>> {
-    return ipcRenderer.invoke("initAutoOn", txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
+    return ipcRenderer.invoke("transceiverInitAutoOn", txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
   },
 
+  /**
+   * 無線機関係・AutoOff
+   */
+  transceiverAutoOff: function (): Promise<ApiResponse<void>> {
+    return ipcRenderer.invoke("transceiverAutoOff");
+  },
   /**
    * 無線機関係・周波数設定コマンドを送信する
    */

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -208,9 +208,10 @@ const apiHandler = {
     txFreqHz: number,
     rxFreqHz: number,
     txMode: string,
-    rxMode: string
+    rxMode: string,
+    toneHz: number | null
   ): Promise<ApiResponse<void>> {
-    return ipcRenderer.invoke("initAutoOn", txFreqHz, rxFreqHz, txMode, rxMode);
+    return ipcRenderer.invoke("initAutoOn", txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
   },
 
   /**

--- a/src/main/service/TransceiverSerivice.ts
+++ b/src/main/service/TransceiverSerivice.ts
@@ -94,6 +94,18 @@ export default class TransceiverService {
   }
 
   /**
+   * 無線機関係・AutoOff
+   */
+  public async autoOff() {
+    if (!this.controller) {
+      return;
+    }
+
+    // AutoOnの初期処理を実行する
+    await this.controller.autoOff();
+  }
+
+  /**
    * 無線機を変更する
    * @param transceiverConfig 無線機設定
    */

--- a/src/main/service/TransceiverSerivice.ts
+++ b/src/main/service/TransceiverSerivice.ts
@@ -84,13 +84,13 @@ export default class TransceiverService {
   /**
    * 無線機関係・AutoOn時の初期処理
    */
-  public async initAutoOn(txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string) {
+  public async initAutoOn(txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string, toneHz: number | null) {
     if (!this.controller) {
       return;
     }
 
     // AutoOnの初期処理を実行する
-    await this.controller.initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode);
+    await this.controller.initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
   }
 
   /**

--- a/src/main/service/TransceiverSerivice.ts
+++ b/src/main/service/TransceiverSerivice.ts
@@ -101,7 +101,6 @@ export default class TransceiverService {
       return;
     }
 
-    // AutoOnの初期処理を実行する
     await this.controller.autoOff();
   }
 

--- a/src/main/service/transceiver/controller/TransceiverControllerBase.ts
+++ b/src/main/service/transceiver/controller/TransceiverControllerBase.ts
@@ -31,6 +31,11 @@ export default abstract class TransceiverControllerBase {
   ): Promise<void>;
 
   /**
+   * 無線機関係・AutoOff
+   */
+  public abstract autoOff(): Promise<void>;
+
+  /**
    * 無線機に送信する周波数を設定する
    * @param {(UplinkType | DownlinkType)} frequencyModel 周波数設定
    */

--- a/src/main/service/transceiver/controller/TransceiverControllerBase.ts
+++ b/src/main/service/transceiver/controller/TransceiverControllerBase.ts
@@ -22,7 +22,13 @@ export default abstract class TransceiverControllerBase {
   /**
    * 無線機関係・AutoOn時の初期処理
    */
-  public abstract initAutoOn(txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string): Promise<void>;
+  public abstract initAutoOn(
+    txFreqHz: number,
+    rxFreqHz: number,
+    txMode: string,
+    rxMode: string,
+    toneHz: number | null
+  ): Promise<void>;
 
   /**
    * 無線機に送信する周波数を設定する

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -326,12 +326,9 @@ export default class TransceiverIcomCmdMaker {
       ...this.makePrefix(),
       // コマンド部
       ...[0x1b, 0x00],
-      parseInt(toneStr[0]),
-      parseInt(toneStr[1]),
-      parseInt(toneStr[2]),
-      parseInt(toneStr[3]),
-      parseInt(toneStr[4]),
-      parseInt(toneStr[5]),
+      parseInt(toneStr[0] + toneStr[1], 16),
+      parseInt(toneStr[2] + toneStr[3], 16),
+      parseInt(toneStr[4] + toneStr[5], 16),
       ...this.makeSuffix(),
     ]);
 
@@ -356,8 +353,8 @@ export default class TransceiverIcomCmdMaker {
 
     // 小数点付きの周波数の場合
     if (toneHz % 1 !== 0) {
-      // 10倍して文字列化
-      const toneStr = (toneHz * 10).toString();
+      // 10倍して文字列化（四捨五入は浮動小数点誤差対策）
+      const toneStr = Math.round(toneHz * 10).toString();
       return toneStr.padStart(6, "0");
     }
 

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -298,4 +298,71 @@ export default class TransceiverIcomCmdMaker {
       ...this.makeSuffix(),
     ]);
   }
+
+  /**
+   * TONEの設定（On/Off）コマンドを返す
+   */
+  public makeSetToneCmd(isOn: boolean): Uint8Array {
+    const toneCmd = new Uint8Array([
+      ...this.makePrefix(),
+      // コマンド部
+      ...[0x16, 0x42],
+      isOn ? 0x01 : 0x00, // 00: Off, 01: On
+      ...this.makeSuffix(),
+    ]);
+    return toneCmd;
+  }
+
+  /**
+   * TONE（レピータ用トーン）周波数の設定コマンドを返す
+   * @param toneHz
+   * @returns
+   */
+  public makeSetToneFreqCmd(toneHz: number): Uint8Array {
+    // 周波数を"00XXXX"形式の文字列に変換
+    const toneStr = this.geneToneHzStr(toneHz);
+
+    const toneCmd = new Uint8Array([
+      ...this.makePrefix(),
+      // コマンド部
+      ...[0x1b, 0x00],
+      parseInt(toneStr[0]),
+      parseInt(toneStr[1]),
+      parseInt(toneStr[2]),
+      parseInt(toneStr[3]),
+      parseInt(toneStr[4]),
+      parseInt(toneStr[5]),
+      ...this.makeSuffix(),
+    ]);
+
+    return toneCmd;
+  }
+
+  /**
+   * TONE周波数設定コマンドのデータ部を返す
+   * @param toneHz
+   * @returns 以下形式の文字列を返す
+   *     1桁目:0（固定）
+   *     2桁目:0（固定）
+   *     3桁目:100Hz桁
+   *     4桁目:10Hz桁
+   *     5桁目:1Hz桁
+   *     6桁目:0.1Hz桁
+   */
+  private geneToneHzStr(toneHz: number): string {
+    if (toneHz > 999.9) {
+      throw new Error("toneHzは999.9以下の値を指定してください。");
+    }
+
+    // 小数点付きの周波数の場合
+    if (toneHz % 1 !== 0) {
+      // 10倍して文字列化
+      const toneStr = (toneHz * 10).toString();
+      return toneStr.padStart(6, "0");
+    }
+
+    // 小数点なしの場合（末尾に0.1Hz桁の0を付与）
+    const toneStr = toneHz.toString() + "0";
+    return toneStr.padStart(6, "0");
+  }
 }

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -185,13 +185,13 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     if (rxModeValue) {
       const cmdData = this.cmdMaker.makeSetOpeMode(rxModeValue);
       await this.sendAndWaitRecv(cmdData, "SET_MODE");
-      AppMainLogger.info(`Rx運用モード（RST→無線機） ${rxModeText}`);
+      AppMainLogger.debug(`Rx運用モード（RST→無線機） ${rxModeText}`);
     }
 
     // メインバンド（Rx）のデータモードを設定する
     const cmdData = this.cmdMaker.makeSetDataMode(this.state.currentRxDataMode);
     await this.sendAndWaitRecv(cmdData, "SET_DATA_MODE");
-    AppMainLogger.info(`Rxデータモード（RST→無線機） ${this.state.currentRxDataMode}`);
+    AppMainLogger.debug(`Rxデータモード（RST→無線機） ${this.state.currentRxDataMode}`);
 
     // メインバンド（Rx）のトーン設定
     await this.setupTone(toneHz);
@@ -210,13 +210,13 @@ export default class TransceiverIcomController extends TransceiverSerialControll
       if (txModeValue) {
         const cmdData = this.cmdMaker.makeSetOpeMode(txModeValue);
         await this.sendAndWaitRecv(cmdData, "SET_MODE");
-        AppMainLogger.info(`Tx運用モード（RST→無線機） ${txModeText}`);
+        AppMainLogger.debug(`Tx運用モード（RST→無線機） ${txModeText}`);
       }
 
       // サブバンド（Tx）のデータモードを設定する
       const cmdData = this.cmdMaker.makeSetDataMode(this.state.currentTxDataMode);
       await this.sendAndWaitRecv(cmdData, "SET_DATA_MODE");
-      AppMainLogger.info(`Txデータモード（RST→無線機） ${this.state.currentTxDataMode}`);
+      AppMainLogger.debug(`Txデータモード（RST→無線機） ${this.state.currentTxDataMode}`);
 
       // サブバンド（Tx）のトーン設定
       await this.setupTone(toneHz);
@@ -317,11 +317,11 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     this.state.setRecvRxFreqHz(TransceiverIcomRecvParser.parseFreq(recvDataMainFreq));
     // メイン・運用モードの取得
     const recvMainMode = await this.sendAndWaitRecv(this.cmdMaker.makeGetMode(), "GET_MODE");
-    AppMainLogger.info(`Rx運用モード 取得要求（RST→無線機）`);
+    AppMainLogger.debug(`Rx運用モード 取得要求（RST→無線機）`);
     await this.handleRecvData(recvMainMode);
     // メイン・データモードの取得
     const recvMainDataMode = await this.sendAndWaitRecv(this.cmdMaker.makeGetDataMode(), "GET_DATA_MODE");
-    AppMainLogger.info(`Rxデータモード 取得要求（RST→無線機）`);
+    AppMainLogger.debug(`Rxデータモード 取得要求（RST→無線機）`);
     await this.handleRecvData(recvMainDataMode);
   }
 
@@ -601,7 +601,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     // データ送信
     const cmdData = this.cmdMaker.makeSetSatelliteMode(isSatelliteMode);
     await this.sendAndWaitRecv(cmdData, "SET_MODE");
-    AppMainLogger.info(`サテライトモード（RST→無線機） ${isSatelliteMode}`);
+    AppMainLogger.debug(`サテライトモード（RST→無線機） ${isSatelliteMode}`);
 
     // サテライトモードの設定を保持する
     this.state.isSatelliteMode = isSatelliteMode;
@@ -713,7 +713,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
         continue;
       }
 
-      // AppMainLogger.info(`onRecv: ${this.recvBuffer}`);
+      // AppMainLogger.debug(`onRecv: ${this.recvBuffer}`);
 
       // コールバックが設定されている場合は、ディスパッチにてコールバックを呼び出し
       if (this.recvCallbackType) {
@@ -938,18 +938,18 @@ export default class TransceiverIcomController extends TransceiverSerialControll
         // メインバンドの受信データをRx周波数とする
         res.data = { downlinkHz: freqHz, downlinkMode: "" } as DownlinkType;
         this.state.setRecvRxFreqHz(freqHz);
-        AppMainLogger.info(`Rx周波数 （RST←無線機）`);
+        AppMainLogger.debug(`Rx周波数 （RST←無線機）`);
       } else {
         // サブバンドは受信データをTx周波数とする
         res.data = { uplinkHz: freqHz, uplinkMode: "" } as UplinkType;
         this.state.setRecvTxFreqHz(freqHz);
-        AppMainLogger.info(`Tx周波数 （RST←無線機）`);
+        AppMainLogger.debug(`Tx周波数 （RST←無線機）`);
       }
     } else {
       // サテライトモードがOFFの場合は、受信データをアップリンク周波数とする
       res.data = { uplinkHz: freqHz, uplinkMode: "" } as UplinkType;
       this.state.setRecvTxFreqHz(freqHz);
-      AppMainLogger.info(`Tx周波数 （RST←無線機） サテライトOff`);
+      AppMainLogger.debug(`Tx周波数 （RST←無線機） サテライトOff`);
     }
 
     // 周波数のコールバック呼び出し
@@ -989,7 +989,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
           downlinkMode: modeText,
         } as DownlinkType;
 
-        AppMainLogger.info(`Rx運用モード（RST←無線機） ${modeText}`);
+        AppMainLogger.debug(`Rx運用モード（RST←無線機） ${modeText}`);
       } else {
         this.state.currentTxOpeMode = recvMode;
         const modeText = this.makeModeText(this.state.currentTxOpeMode, this.state.currentTxDataMode);
@@ -999,7 +999,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
           uplinkMode: modeText,
         } as UplinkType;
 
-        AppMainLogger.info(`Tx運用モード（RST←無線機） ${modeText}`);
+        AppMainLogger.debug(`Tx運用モード（RST←無線機） ${modeText}`);
       }
 
       // サテライトモードがOFFの場合は受信データをアップリンクの運用モードとする
@@ -1011,7 +1011,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
         uplinkMode: modeText,
       } as UplinkType;
 
-      AppMainLogger.info(`Tx運用モード（RST←無線機） ${modeText}`);
+      AppMainLogger.debug(`Tx運用モード（RST←無線機） ${modeText}`);
     }
 
     // 運用モードのコールバック呼び出し
@@ -1046,7 +1046,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
           downlinkMode: modeText,
         } as DownlinkType;
 
-        AppMainLogger.info(`Rxデータモード（RST←無線機） ${modeText}`);
+        AppMainLogger.debug(`Rxデータモード（RST←無線機） ${modeText}`);
       } else {
         this.state.currentTxDataMode = recvDataMode;
         const modeText = this.makeModeText(this.state.currentTxOpeMode, this.state.currentTxDataMode);
@@ -1056,7 +1056,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
           uplinkMode: modeText,
         } as UplinkType;
 
-        AppMainLogger.info(`Txデータモード（RST←無線機） ${modeText}`);
+        AppMainLogger.debug(`Txデータモード（RST←無線機） ${modeText}`);
       }
 
       // サテライトモードがOFFの場合は受信データをアップリンクの運用モードとする
@@ -1068,7 +1068,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
         uplinkMode: modeText,
       } as UplinkType;
 
-      AppMainLogger.info(`Txデータモード（RST←無線機） ${modeText}`);
+      AppMainLogger.debug(`Txデータモード（RST←無線機） ${modeText}`);
     }
 
     // 運用モードのコールバック呼び出し

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -226,6 +226,27 @@ export default class TransceiverIcomController extends TransceiverSerialControll
   }
 
   /**
+   * AutoOff
+   */
+  public override async autoOff(): Promise<void> {
+    AppMainLogger.info(`無線機Auto Off処理を開始します。`);
+
+    // サブ・トーンOff
+    if (this.state.isSatelliteMode) {
+      this.state.isMain = false;
+      await this.sendAndWaitRecv(this.cmdMaker.makeSwitchToSubBand(), "SWITCH");
+      await this.sendToneOff();
+    }
+
+    // メイン・トーンOff
+    this.state.isMain = true;
+    await this.sendAndWaitRecv(this.cmdMaker.makeSwitchToMainBand(), "SWITCH");
+    await this.sendToneOff();
+
+    AppMainLogger.info(`無線機AutoをOffにしました。`);
+  }
+
+  /**
    * 無線機の初期化を行う
    */
   private async initTranceiver() {

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -194,7 +194,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     AppMainLogger.info(`Rxデータモード（RST→無線機） ${this.state.currentRxDataMode}`);
 
     // メインバンド（Rx）のトーン設定
-    this.setupTone(toneHz);
+    await this.setupTone(toneHz);
 
     // サブバンド
     // サテライトモードの場合は、サブバンド（Tx）の周波数とモードも設定する
@@ -219,7 +219,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
       AppMainLogger.info(`Txデータモード（RST→無線機） ${this.state.currentTxDataMode}`);
 
       // サブバンド（Tx）のトーン設定
-      this.setupTone(toneHz);
+      await this.setupTone(toneHz);
     }
 
     AppMainLogger.info(`無線機AutoをOnにしました。`);
@@ -1217,5 +1217,15 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     const toneFreqCmd = this.cmdMaker.makeSetToneFreqCmd(toneHz);
     await this.sendAndWaitRecv(toneFreqCmd, "SET_TONE");
     AppMainLogger.debug(`TONE周波数設定（RST→無線機） ${toneHz}`);
+  }
+
+  /**
+   * TONE Offを無線機に送信する
+   */
+  private async sendToneOff(): Promise<void> {
+    // TONE周波数の設定/未設定に従い、TONE On/Offを無線機に設定する
+    const toneOnOffCmd = this.cmdMaker.makeSetToneCmd(false);
+    await this.sendAndWaitRecv(toneOnOffCmd, "SET_TONE");
+    AppMainLogger.debug(`TONE On/Off設定（RST→無線機） Off`);
   }
 }

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -1244,7 +1244,6 @@ export default class TransceiverIcomController extends TransceiverSerialControll
    * TONE Offを無線機に送信する
    */
   private async sendToneOff(): Promise<void> {
-    // TONE周波数の設定/未設定に従い、TONE On/Offを無線機に設定する
     const toneOnOffCmd = this.cmdMaker.makeSetToneCmd(false);
     await this.sendAndWaitRecv(toneOnOffCmd, "SET_TONE");
     AppMainLogger.debug(`TONE On/Off設定（RST→無線機） Off`);

--- a/src/renderer/api/ApiTransceiver.ts
+++ b/src/renderer/api/ApiTransceiver.ts
@@ -24,14 +24,21 @@ export default class ApiTransceiver {
   /**
    * AutoOn時の初期処理
    */
-  public static async initAutoOn(
+  public static async transceiverInitAutoOn(
     txFreqHz: number,
     rxFreqHz: number,
     txMode: string,
     rxMode: string,
     toneHz: number | null
   ): Promise<void> {
-    await window.rstApi.initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
+    await window.rstApi.transceiverInitAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
+  }
+
+  /**
+   * AutoOff時の初期処理
+   */
+  public static async transceiverAutoOff(): Promise<void> {
+    await window.rstApi.transceiverAutoOff();
   }
 
   /**

--- a/src/renderer/api/ApiTransceiver.ts
+++ b/src/renderer/api/ApiTransceiver.ts
@@ -24,8 +24,14 @@ export default class ApiTransceiver {
   /**
    * AutoOn時の初期処理
    */
-  public static async initAutoOn(txFreqHz: number, rxFreqHz: number, txMode: string, rxMode: string): Promise<void> {
-    await window.rstApi.initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode);
+  public static async initAutoOn(
+    txFreqHz: number,
+    rxFreqHz: number,
+    txMode: string,
+    rxMode: string,
+    toneHz: number | null
+  ): Promise<void> {
+    await window.rstApi.initAutoOn(txFreqHz, rxFreqHz, txMode, rxMode, toneHz);
   }
 
   /**

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -144,7 +144,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       TransceiverUtil.parseNumber(txFrequency.value),
       TransceiverUtil.parseNumber(rxFrequency.value),
       txOpeMode.value,
-      rxOpeMode.value
+      rxOpeMode.value,
+      transceiverSetting.toneHz
     );
 
     // ドップラーシフトの基準周波数を設定する

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -140,7 +140,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     }
 
     // Auto開始をメイン側に連携する
-    await ApiTransceiver.initAutoOn(
+    await ApiTransceiver.transceiverInitAutoOn(
       TransceiverUtil.parseNumber(txFrequency.value),
       TransceiverUtil.parseNumber(rxFrequency.value),
       txOpeMode.value,
@@ -177,6 +177,10 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
    * Autoモードを停止する
    */
   async function stopAutoMode() {
+    // Auto終了をメイン側に連携する
+    await ApiTransceiver.transceiverAutoOff();
+
+    // Autoモードの周波数更新を停止する
     if (!stopUpdateFreq()) {
       return;
     }

--- a/src/renderer/service/ActiveSatServiceHub.ts
+++ b/src/renderer/service/ActiveSatServiceHub.ts
@@ -63,6 +63,8 @@ export default class ActiveSatServiceHub {
   private satelliteMode: boolean = false;
   // アクティブ衛星のトラッキングモード
   private satTrackMode: string | null = null;
+  // アクティブ衛星のTone周波数
+  private toneHz: number | null = null;
 
   /**
    * シングルトンのため、コンストラクタは隠蔽
@@ -214,82 +216,85 @@ export default class ActiveSatServiceHub {
   /**
    * アクティブ衛星の無線設定を取得する
    */
-  private async getTransceiverSetting() {
+  private async getTransceiverSetting(): Promise<void> {
     // 衛星グループを取得
     const satGrp = await ApiActiveSat.getActiveSatelliteGroup();
     if (!satGrp || !satGrp.mainSattelliteTle) {
-      return 0;
+      return;
     }
 
     const appConfigSatellite = await ApiAppConfigSatellite.getUserRegisteredAppConfigSatellite(
       satGrp.mainSatelliteId,
       satGrp.activeSatelliteGroupId
     );
-    if (appConfigSatellite) {
-      // アクティブ衛星のアップリンク設定
-      switch (appConfigSatellite.autoModeUplinkFreq) {
-        case 2:
-          // アップリンク設定が2の場合は、設定2を使用する
-          this.uplinkFreq = {
-            uplinkHz: appConfigSatellite.uplink2.uplinkHz ?? null,
-            uplinkMode: appConfigSatellite.uplink2.uplinkMode,
-          };
-          break;
-        case 3:
-          // アップリンク設定が3の場合は、設定3を使用する
-          this.uplinkFreq = {
-            uplinkHz: appConfigSatellite.uplink3.uplinkHz ?? null,
-            uplinkMode: appConfigSatellite.uplink3.uplinkMode,
-          };
-          break;
-        default:
-          // それ以外の場合は、設定1を使用する
-          this.uplinkFreq = {
-            uplinkHz: appConfigSatellite.uplink1.uplinkHz ?? null,
-            uplinkMode: appConfigSatellite.uplink1.uplinkMode,
-          };
-          break;
-      }
-
-      // アクティブ衛星のダウンリンク設定
-      switch (appConfigSatellite.autoModeDownlinkFreq) {
-        case 2:
-          // ダウンリンク設定が2の場合は、設定2を使用する
-          this.downlinkFreq = {
-            downlinkHz: appConfigSatellite.downlink2.downlinkHz ?? null,
-            downlinkMode: appConfigSatellite.downlink2.downlinkMode,
-          };
-          break;
-        case 3:
-          // ダウンリンク設定が3の場合は、設定3を使用する
-          this.downlinkFreq = {
-            downlinkHz: appConfigSatellite.downlink3.downlinkHz ?? null,
-            downlinkMode: appConfigSatellite.downlink3.downlinkMode,
-          };
-          break;
-        default:
-          // それ以外は設定1を使用する
-          this.downlinkFreq = {
-            downlinkHz: appConfigSatellite.downlink1.downlinkHz ?? null,
-            downlinkMode: appConfigSatellite.downlink1.downlinkMode,
-          };
-          break;
-      }
-
-      // アクティブ衛星のビーコン設定
-      this.beaconFreq = {
-        beaconHz: appConfigSatellite.beacon.beaconHz ?? null,
-        beaconMode: appConfigSatellite.beacon.beaconMode,
-      };
-
-      // アクティブ衛星の衛星モード
-      this.satelliteMode = appConfigSatellite.enableSatelliteMode;
-
-      // アクティブ衛星のトラッキングモード
-      this.satTrackMode = appConfigSatellite.enableSatelliteMode ? appConfigSatellite.satelliteMode : null;
+    if (!appConfigSatellite) {
+      return;
     }
 
-    return 0;
+    // アクティブ衛星のアップリンク設定
+    switch (appConfigSatellite.autoModeUplinkFreq) {
+      case 2:
+        // アップリンク設定が2の場合は、設定2を使用する
+        this.uplinkFreq = {
+          uplinkHz: appConfigSatellite.uplink2.uplinkHz ?? null,
+          uplinkMode: appConfigSatellite.uplink2.uplinkMode,
+        };
+        break;
+      case 3:
+        // アップリンク設定が3の場合は、設定3を使用する
+        this.uplinkFreq = {
+          uplinkHz: appConfigSatellite.uplink3.uplinkHz ?? null,
+          uplinkMode: appConfigSatellite.uplink3.uplinkMode,
+        };
+        break;
+      default:
+        // それ以外の場合は、設定1を使用する
+        this.uplinkFreq = {
+          uplinkHz: appConfigSatellite.uplink1.uplinkHz ?? null,
+          uplinkMode: appConfigSatellite.uplink1.uplinkMode,
+        };
+        break;
+    }
+
+    // アクティブ衛星のダウンリンク設定
+    switch (appConfigSatellite.autoModeDownlinkFreq) {
+      case 2:
+        // ダウンリンク設定が2の場合は、設定2を使用する
+        this.downlinkFreq = {
+          downlinkHz: appConfigSatellite.downlink2.downlinkHz ?? null,
+          downlinkMode: appConfigSatellite.downlink2.downlinkMode,
+        };
+        break;
+      case 3:
+        // ダウンリンク設定が3の場合は、設定3を使用する
+        this.downlinkFreq = {
+          downlinkHz: appConfigSatellite.downlink3.downlinkHz ?? null,
+          downlinkMode: appConfigSatellite.downlink3.downlinkMode,
+        };
+        break;
+      default:
+        // それ以外は設定1を使用する
+        this.downlinkFreq = {
+          downlinkHz: appConfigSatellite.downlink1.downlinkHz ?? null,
+          downlinkMode: appConfigSatellite.downlink1.downlinkMode,
+        };
+        break;
+    }
+
+    // アクティブ衛星のビーコン設定
+    this.beaconFreq = {
+      beaconHz: appConfigSatellite.beacon.beaconHz ?? null,
+      beaconMode: appConfigSatellite.beacon.beaconMode,
+    };
+
+    // アクティブ衛星の衛星モード
+    this.satelliteMode = appConfigSatellite.enableSatelliteMode;
+
+    // アクティブ衛星のトラッキングモード
+    this.satTrackMode = appConfigSatellite.enableSatelliteMode ? appConfigSatellite.satelliteMode : null;
+
+    // アクティブ衛星のTone周波数
+    this.toneHz = appConfigSatellite.toneHz;
   }
 
   /**
@@ -390,6 +395,7 @@ export default class ActiveSatServiceHub {
     beacon: BeaconType | null;
     satelliteMode: boolean;
     satTrackMode: string | null;
+    toneHz: number | null;
   } {
     return {
       downlink: this.downlinkFreq,
@@ -397,6 +403,7 @@ export default class ActiveSatServiceHub {
       beacon: this.beaconFreq,
       satelliteMode: this.satelliteMode,
       satTrackMode: this.satTrackMode,
+      toneHz: this.toneHz,
     };
   }
 


### PR DESCRIPTION
TONE設定対応。
- TONE周波数が衛星に設定されている場合、周波数AutoのON時にTONE On、およびその周波数のCI-Vを送る。
- 未設定の場合はTONE Offをおくる。
- AutoOFF時にはTOEN Offにする。

他、以下を修正。
- `src\main\initializeIpcEvent.ts` の`removeAllListeners`定義不足を追加。
