### PR TITLE
ICOM無線機のTONE対応（FM系モードの場合にのみAutoOnでTONEを設定する）

### DIFF
--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -194,7 +194,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     AppMainLogger.debug(`Rxデータモード（RST→無線機） ${this.state.currentRxDataMode}`);
 
     // メインバンド（Rx）のトーン設定
-    await this.setupTone(toneHz);
+    await this.setupTone(rxModeText, toneHz);
 
     // サブバンド
     // サテライトモードの場合は、サブバンド（Tx）の周波数とモードも設定する
@@ -219,7 +219,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
       AppMainLogger.debug(`Txデータモード（RST→無線機） ${this.state.currentTxDataMode}`);
 
       // サブバンド（Tx）のトーン設定
-      await this.setupTone(toneHz);
+      await this.setupTone(txModeText, toneHz);
     }
 
     AppMainLogger.info(`無線機AutoをOnにしました。`);
@@ -1223,7 +1223,14 @@ export default class TransceiverIcomController extends TransceiverSerialControll
   /**
    * TONE設定を無線機に送信する
    */
-  private async setupTone(toneHz: number | null): Promise<void> {
+  private async setupTone(modeText: string | null, toneHz: number | null): Promise<void> {
+    // 運用モードがTONE設定可能なモードでない場合（FM、FM-D以外の場合）はTONE Offを送信して処理終了
+    // memo: FM、FM-DでのみTONE設定が可能なため
+    if (modeText !== Constant.Transceiver.OpeMode.FM && modeText !== Constant.Transceiver.OpeMode.FM_D) {
+      await this.sendToneOff();
+      return;
+    }
+
     // TONE周波数の設定/未設定に従い、TONE On/Offを無線機に設定する
     const toneOnOffCmd = this.cmdMaker.makeSetToneCmd(toneHz ? true : false);
     await this.sendAndWaitRecv(toneOnOffCmd, "SET_TONE");


### PR DESCRIPTION
FM、FM-DでのみTONE設定が可能なため、AutoOn時の処理に以下の条件を追加した。
- 運用モードがTONE設定可能なモードでない場合（FM、FM-D以外の場合）はTONE Offを送信する。
