### PR TITLE
無線機からのトランシーブデータの取りこぼしバグの修正

### DIFF
--- a/src/main/service/transceiver/controller/TransceiverIcomRecvParser.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomRecvParser.ts
@@ -116,7 +116,7 @@ export default class TransceiverIcomRecvParser {
   /**
    * 受信データについて、プリアンブル以降を読む（先頭に"00"がついている場合があるので、そこは読み捨てる）
    */
-  public static trimRecData(recvData: string) {
+  public static trimRecvData(recvData: string) {
     const startIdx = recvData.indexOf("fefe");
     if (startIdx === -1) {
       return "";

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -677,10 +677,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         const recvTxFreq = freqData.uplinkHz;
         AppRendererLogger.info(`トランシーブ Tx周波数 Tx:${recvTxFreq}`);
 
-        // AutoOff時は画面のアップリンク周波数を更新して終了
-        // memo: AutoOn時は、ドップラーシフト値で画面の周波数を更新するため、ここでは更新しない
+        // 画面のアップリンク周波数を更新
+        txFrequency.value = TransceiverUtil.formatWithDot(recvTxFreq);
+
+        // AutoOff時は処理終了
         if (!autoStore.tranceiverAuto) {
-          txFrequency.value = TransceiverUtil.formatWithDot(recvTxFreq);
           return;
         }
         // 以降、AutoOn時の基準周波数更新処理
@@ -699,10 +700,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         const recvRxFreq = freqData.downlinkHz;
         AppRendererLogger.info(`トランシーブ Rx周波数 Rx:${recvRxFreq}`);
 
-        // AutoOff時は画面のダウンリンク周波数を更新して終了
-        // memo: AutoOn時は、ドップラーシフト値で画面の周波数を更新するため、ここでは更新しない
+        // 画面のダウンリンク周波数を更新
+        rxFrequency.value = TransceiverUtil.formatWithDot(recvRxFreq);
+
+        // AutoOff時は処理終了
         if (!autoStore.tranceiverAuto) {
-          rxFrequency.value = TransceiverUtil.formatWithDot(recvRxFreq);
           return;
         }
         // 以降、AutoOn時の基準周波数更新処理


### PR DESCRIPTION
無線機からのトランシーブデータの取りこぼしバグの対応。

取りこぼしの原因
- 無線機からのデータは非同期で受信される。
- 受信バッファのデータを元に処理を行った後に、受信バッファをクリアしていたため、処理中に受信バッファにデータが追加される。
- 追加された受信バッファもクリアしていたため、取りこぼしが発生していた。

対応
- 受信バッファのデータが揃った直後にデータを切り出し、受信バッファをクリアするように修正。
- 受信データの処理は切り出しデータを元に行うように修正。

その他、AutoOn時＋AOS以外の時間帯においても、無線機の周波数変更が画面に反映されるように修正。

