### PR TITLE
周波数ラベルの微調整

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
@@ -202,6 +202,9 @@
   @extend .item_label;
   background-color: $green;
   color: $black100;
+  display: inline-block;
+  width: 1.5em;
+  text-align: center;
 }
 
 .freq_label_inactive {


### PR DESCRIPTION
# 前提
- 周波数ラベルのRxとTxでサイズが文字フォントの関係で微妙に違う

# 実装概要
- 周波数ラベルはRx/Txだけに使う前提で文字サイズを固定
<img width="456" height="430" alt="image" src="https://github.com/user-attachments/assets/4b776227-8489-4691-acad-b5c4c423fb30" />

# 注意点
- なし

# 関連
- なし