### PR TITLE
無線機でのモード変更時にバンド切り替えを抑止する

### DIFF
--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -272,6 +272,8 @@ export default class Constant {
     static readonly DOPPLER_SHIFT_RANGE_SEC = 60;
     // 周波数データ(トランシーブ)受信時の待機時間[単位:ミリ秒]
     static readonly TRANSCEIVE_WAIT_MS = 2000;
+    // 運用モード(トランシーブ)受信時の待機時間[単位:ミリ秒]
+    static readonly TRANSCEIVE_MODE_WAIT_MS = 5000;
   };
 
   /**

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -1325,7 +1325,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
       clearTimeout(this.transceiveWaitTimer);
     }
 
-    // 指定秒後、無線機への周波数の送信一時停止を解除する
+    // 指定ミリ秒後、無線機への周波数の送信一時停止を解除する
     this.transceiveWaitTimer = setTimeout(() => {
       this.isWaitSendFreq = false;
       this.transceiveWaitTimer = null;


### PR DESCRIPTION
無線機でのモード変更時、RSTからのバンド切り替えが発生すると、意図したバンドのモード設定操作が困難となる。
これを改善するため、バンド切り替えを一定時間停止するように修正。