### PR TITLE
"67.0"のTONEの設定が無線機に反映されたないバグ対応

### DIFF
--- a/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
+++ b/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
@@ -17,9 +17,9 @@ describe("TransceiverIcomCmdMaker.geneToneHzStrのテスト", () => {
     expect(maker["geneToneHzStr"](999.9)).toBe("009999");
     expect(maker["geneToneHzStr"](67.0)).toBe("000670");
 
-    // Issue対応
-    // memo: 引数の型はnumberだが、app_config.jsonではStringで保持されるため、動的にはString型が渡されるため
-    //       geneToneHzStr()での小数点付きか？の判定で不具合が発生していた。
+    // TONE値をStringで渡した場合のテスト
+    // memo: 引数の型はnumberだが、app_config.jsonではStringで保持されるため、実行時はString型が渡される。
+    //       そのためgeneToneHzStr()での小数点付きか？の判定で不具合が発生していた。
     expect(maker["geneToneHzStr"]("67.0" as unknown as number)).toBe("000670");
   });
 

--- a/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
+++ b/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
@@ -21,6 +21,7 @@ describe("TransceiverIcomCmdMaker.geneToneHzStrのテスト", () => {
     // memo: 引数の型はnumberだが、app_config.jsonではStringで保持されるため、実行時はString型が渡される。
     //       そのためgeneToneHzStr()での小数点付きか？の判定で不具合が発生していた。
     expect(maker["geneToneHzStr"]("67.0" as unknown as number)).toBe("000670");
+    expect(maker["geneToneHzStr"]("67" as unknown as number)).toBe("000670");
   });
 
   it("桁あふれの場合は例外が送出される", () => {

--- a/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
+++ b/src/__tests__/main/service/transceiver/controller/TransceiverIcomCmdMaker/TransceiverIcomCmdMaker_geneToneHzStr.test.ts
@@ -15,6 +15,12 @@ describe("TransceiverIcomCmdMaker.geneToneHzStrのテスト", () => {
     expect(maker["geneToneHzStr"](12.3)).toBe("000123");
     expect(maker["geneToneHzStr"](123.4)).toBe("001234");
     expect(maker["geneToneHzStr"](999.9)).toBe("009999");
+    expect(maker["geneToneHzStr"](67.0)).toBe("000670");
+
+    // Issue対応
+    // memo: 引数の型はnumberだが、app_config.jsonではStringで保持されるため、動的にはString型が渡されるため
+    //       geneToneHzStr()での小数点付きか？の判定で不具合が発生していた。
+    expect(maker["geneToneHzStr"]("67.0" as unknown as number)).toBe("000670");
   });
 
   it("桁あふれの場合は例外が送出される", () => {

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -352,14 +352,15 @@ export default class TransceiverIcomCmdMaker {
     }
 
     // 小数点付きの周波数の場合
-    if (toneHz % 1 !== 0) {
+    const toneStr = toneHz.toString();
+    if (toneStr.indexOf(".") >= 0) {
       // 10倍して文字列化（四捨五入は浮動小数点誤差対策）
       const toneStr = Math.round(toneHz * 10).toString();
+      // 前方6桁0埋めで返す
       return toneStr.padStart(6, "0");
     }
 
-    // 小数点なしの場合（末尾に0.1Hz桁の0を付与）
-    const toneStr = toneHz.toString() + "0";
-    return toneStr.padStart(6, "0");
+    // 小数点なしの場合（末尾に0.1Hz桁の0を付与し、前方6桁0埋め）
+    return (toneStr + "0").padStart(6, "0");
   }
 }

--- a/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomCmdMaker.ts
@@ -347,17 +347,18 @@ export default class TransceiverIcomCmdMaker {
    *     6桁目:0.1Hz桁
    */
   private geneToneHzStr(toneHz: number): string {
-    if (toneHz > 999.9) {
+    const toneNum = Number(toneHz);
+    if (toneNum > 999.9) {
       throw new Error("toneHzは999.9以下の値を指定してください。");
     }
 
     // 小数点付きの周波数の場合
-    const toneStr = toneHz.toString();
+    const toneStr = toneNum.toString();
     if (toneStr.indexOf(".") >= 0) {
       // 10倍して文字列化（四捨五入は浮動小数点誤差対策）
-      const toneStr = Math.round(toneHz * 10).toString();
+      const toneStrMultiplied = Math.round(toneNum * 10).toString();
       // 前方6桁0埋めで返す
-      return toneStr.padStart(6, "0");
+      return toneStrMultiplied.padStart(6, "0");
     }
 
     // 小数点なしの場合（末尾に0.1Hz桁の0を付与し、前方6桁0埋め）


### PR DESCRIPTION
#146 の対応。

■事象
無線機設定のTONEに"67.0"を設定した場合、無線機に反映されない。

■原因
- TONE値のCI-Vコマンド生成処理において、引数の型はnumber。
- ただし、app_config.jsonではTONE値をStringで保持されるため、実行時はにはString型が渡されるため CI-Vコマンド生成処理での小数点なしと見なされた。実際は小数点付きであり、期待する戻り値"000670"に対して、"067.00"が返却されていた。
- "067.00"を元にしたコマンド生成が行われて、無線機にTONEが設定されなかった。

■対応
- TONE値のCI-Vコマンド生成処理において、"67.0"などの文字列が入力されても期待する値を返却でるように修正。
