### PR TITLE
衛星切り替え時にメイン側のAutoOff処理を実行する

### DIFF
--- a/src/main/service/transceiver/controller/TransceiverIcomState.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomState.ts
@@ -74,6 +74,7 @@ export default class TransceiverIcomState {
 
   /**
    * RSTから無線機に設定したいRx運用モード、データモードをセットする
+   * @param isForce 強制設定（同一モードでも強制的に設定する場合はtrueを指定する）
    */
   public setReqRxMode(mode: string | null, dataMode: string, isForce: boolean = false): void {
     if (!mode) {
@@ -98,6 +99,7 @@ export default class TransceiverIcomState {
 
   /**
    * RSTから無線機に設定したいTx運用モード、データモードをセットする
+   * @param isForce 強制設定（同一モードでも強制的に設定する場合はtrueを指定する）
    */
   public setReqTxMode(mode: string | null, dataMode: string, isForce: boolean = false): void {
     if (!mode) {

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -260,12 +260,15 @@ const isTxActive = computed(() => {
 /**
  * 無線機のAutoモードの状態を監視
  */
-watch(autoStore, async () => {
-  // AutoOffになった場合は、Autoモードの停止処理を実行する
-  if (!autoStore.tranceiverAuto) {
-    await stopAutoMode();
+watch(
+  () => autoStore.tranceiverAuto,
+  async (newVal, oldVal) => {
+    // AutoOn(true) から AutoOff(false) になった場合のみ、Autoモードの停止処理を実行する
+    if (oldVal && !newVal) {
+      await stopAutoMode();
+    }
   }
-});
+);
 </script>
 
 <style lang="scss" scoped>

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -156,7 +156,7 @@ import DateTimePicker from "@/renderer/components/organisms/DateTimePicker/DateT
 import { useStoreAutoState } from "@/renderer/store/useStoreAutoState";
 import CanvasUtil from "@/renderer/util/CanvasUtil";
 import DateUtil from "@/renderer/util/DateUtil";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import useOrbitalPassList from "./useOrbitalPassList";
 import useOverlapPassList from "./useOverlapPassList";
 import useTransceiverCtrl from "./useTransceiverCtrl";
@@ -255,6 +255,16 @@ const isRxActive = computed(() => {
  */
 const isTxActive = computed(() => {
   return execTxDopplerShiftCorrection.value && autoStore.tranceiverAuto;
+});
+
+/**
+ * 無線機のAutoモードの状態を監視
+ */
+watch(autoStore, async () => {
+  // AutoOffになった場合は、Autoモードの停止処理を実行する
+  if (!autoStore.tranceiverAuto) {
+    await stopAutoMode();
+  }
 });
 </script>
 

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -263,8 +263,11 @@ const isTxActive = computed(() => {
 watch(
   () => autoStore.tranceiverAuto,
   async (newVal, oldVal) => {
-    // AutoOn(true) から AutoOff(false) になった場合のみ、Autoモードの停止処理を実行する
+    // AutoOn(true) から AutoOff(false) になった場合
     if (oldVal && !newVal) {
+      // ビーコンモードをOFFにする
+      isBeaconMode.value = false;
+      // Autoモードを停止
       await stopAutoMode();
     }
   }


### PR DESCRIPTION
#144 での指摘対応。
衛星切り替え時、画面上のAutoボタンをOffにしていたが、メイン側への連動を行っていたかった。
Auto状態のステートを監視し、Offになった場合はメイン側への連動を行うように修正。

合わせて、AutoOff時はビーコンもOffにするように修正。