### PR TITLE
周波数トランシーブの際にRSTの周波数と同一の場合は基準周波数の更新をスキップするように修正

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -699,6 +699,19 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         const recvTxFreq = freqData.uplinkHz;
         AppRendererLogger.info(`トランシーブ Tx周波数 Tx:${recvTxFreq}`);
 
+        // 画面のアップリンク周波数と無線機からトランシーブした周波数が同じ場合は処理終了
+        // MEMO: 無線機にて操作対象のバンドの変更などを行うと、周波数を変更せずとも周波数のトランシーブが発生する。
+        //       その場合に基準周波数の更新を行うと意図しない基準周波数の変更が発生するため、同じ場合は処理を終了する。
+        AppRendererLogger.info(`RST Tx周波数 Tx:${txFrequency.value}`);
+        const formattedRecvTxFreq = TransceiverUtil.formatWithDot(recvTxFreq);
+        if (txFrequency.value === formattedRecvTxFreq) {
+          AppRendererLogger.info(`RSTのTx周波数と同一のため基準周波数の更新をスキップします。`);
+          AppRendererLogger.info(
+            `基準周波数 Rx:${dopplerRxBaseFreq.value} Tx:${dopplerTxBaseFreq.value} Sum:${baseFreqSum.value}`
+          );
+          return;
+        }
+
         // 画面のアップリンク周波数を更新
         txFrequency.value = TransceiverUtil.formatWithDot(recvTxFreq);
 
@@ -722,6 +735,19 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         const recvRxFreq = freqData.downlinkHz;
         AppRendererLogger.info(`トランシーブ Rx周波数 Rx:${recvRxFreq}`);
 
+        // 画面のアップリンク周波数と無線機からトランシーブした周波数が同じ場合は処理終了
+        // MEMO: 無線機にて操作対象のバンドの変更などを行うと、周波数を変更せずとも周波数のトランシーブが発生する。
+        //       その場合に基準周波数の更新を行うと意図しない基準周波数の変更が発生するため、同じ場合は処理を終了する。
+        const formattedRecvRxFreq = TransceiverUtil.formatWithDot(recvRxFreq);
+        AppRendererLogger.info(`RST Rx周波数 Rx:${rxFrequency.value} 受信：${formattedRecvRxFreq}`);
+        if (rxFrequency.value === formattedRecvRxFreq) {
+          AppRendererLogger.info(`RSTのRx周波数と同一のため基準周波数の更新をスキップします。`);
+          AppRendererLogger.info(
+            `基準周波数 Rx:${dopplerRxBaseFreq.value} Tx:${dopplerTxBaseFreq.value} Sum:${baseFreqSum.value}`
+          );
+          return;
+        }
+
         // 画面のダウンリンク周波数を更新
         rxFrequency.value = TransceiverUtil.formatWithDot(recvRxFreq);
 
@@ -737,7 +763,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         dopplerTxBaseFreq.value = txBaseFreq;
 
         AppRendererLogger.info(
-          `基準周波数を更新しました。 Rx:${dopplerRxBaseFreq.value} Tx:${dopplerTxBaseFreq.value} Sum:${baseFreqSum.value}`
+          `基準周波数（更新） Rx:${dopplerRxBaseFreq.value} Tx:${dopplerTxBaseFreq.value} Sum:${baseFreqSum.value}`
         );
       }
     });

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -735,7 +735,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         const recvRxFreq = freqData.downlinkHz;
         AppRendererLogger.info(`トランシーブ Rx周波数 Rx:${recvRxFreq}`);
 
-        // 画面のアップリンク周波数と無線機からトランシーブした周波数が同じ場合は処理終了
+        // 画面のダウンリンク周波数と無線機からトランシーブした周波数が同じ場合は処理終了
         // MEMO: 無線機にて操作対象のバンドの変更などを行うと、周波数を変更せずとも周波数のトランシーブが発生する。
         //       その場合に基準周波数の更新を行うと意図しない基準周波数の変更が発生するため、同じ場合は処理を終了する。
         const formattedRecvRxFreq = TransceiverUtil.formatWithDot(recvRxFreq);

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -702,7 +702,6 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         // 画面のアップリンク周波数と無線機からトランシーブした周波数が同じ場合は処理終了
         // MEMO: 無線機にて操作対象のバンドの変更などを行うと、周波数を変更せずとも周波数のトランシーブが発生する。
         //       その場合に基準周波数の更新を行うと意図しない基準周波数の変更が発生するため、同じ場合は処理を終了する。
-        AppRendererLogger.info(`RST Tx周波数 Tx:${txFrequency.value}`);
         const formattedRecvTxFreq = TransceiverUtil.formatWithDot(recvTxFreq);
         if (txFrequency.value === formattedRecvTxFreq) {
           AppRendererLogger.info(`RSTのTx周波数と同一のため基準周波数の更新をスキップします。`);
@@ -739,7 +738,6 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
         // MEMO: 無線機にて操作対象のバンドの変更などを行うと、周波数を変更せずとも周波数のトランシーブが発生する。
         //       その場合に基準周波数の更新を行うと意図しない基準周波数の変更が発生するため、同じ場合は処理を終了する。
         const formattedRecvRxFreq = TransceiverUtil.formatWithDot(recvRxFreq);
-        AppRendererLogger.info(`RST Rx周波数 Rx:${rxFrequency.value} 受信：${formattedRecvRxFreq}`);
         if (rxFrequency.value === formattedRecvRxFreq) {
           AppRendererLogger.info(`RSTのRx周波数と同一のため基準周波数の更新をスキップします。`);
           AppRendererLogger.info(


### PR DESCRIPTION
#147 対応

■事象
- 無線機AutoOnでAOS待機状態の際に、基準周波数が不整値となり、AOS時のドップラーシフトも意図しない値となる。

■原因
- 無線機から周波数のトランシーブが発生した場合は、その周波数をドップラーシフト後の周波数と見なし、基準周波数が再計算される。
- 無線機にて操作バンドの変更などを操作した場合に（周波数を変更していなくても）周波数のトランシーブが発生する。
- AutoOn後の待機状態にて、上記のトランシーブが発生した場合に、意図せず基準周波数が更新された。

■対応
- 周波数トランシーブ時において、RSTの周波数と同一の場合は、基準周波数の更新をスキップするように修正。
- 無線機での周波数の変更は、リニア衛星での周波数合わせで主に行われる。その場合はRSTの周波数と異なる周波数がトランシーブされるため、 同一周波数での基準周波数更新のスキップによる影響はないと推定。
