### PR TITLE
無線機が未接続の場合に「無線機のシリアルが未接続です」のトーストが表示され続けないように修正

### DIFF
--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -389,6 +389,7 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     // 定期コマンド送信を停止
     if (this.sendAndRecvTimer) {
       clearInterval(this.sendAndRecvTimer);
+      this.sendAndRecvTimer = null;
 
       AppMainLogger.info(`無線機の監視とデータの送信を停止しました。`);
     }

--- a/src/main/service/transceiver/controller/TransceiverIcomController.ts
+++ b/src/main/service/transceiver/controller/TransceiverIcomController.ts
@@ -106,7 +106,10 @@ export default class TransceiverIcomController extends TransceiverSerialControll
     this.sendAndRecvTimer = setInterval(async () => {
       // 無線機との接続が準備完了でない場合は処理終了
       if (!this.isReady()) {
+        // シリアル未接続メッセージをレンダラ側へ通知
         this.fireSerialNotConnectedMsg();
+        // 定期コマンド送信を停止
+        this.cancelTimer();
         return;
       }
 


### PR DESCRIPTION
#162 対応

■事象
- 無線機へ一定間隔でデータを送受信している。
- その処理の冒頭で無線機との接続チェックを行っており、未接続の場合はトーストを表示している。
- 一定間隔で再実行されるため、トーストを閉じても再表示を繰り返してしまう。

■対応
- 無線機が未接続の場合、一定間隔の送受信機能を終了するようした。
- 無線機が接続された場合は、無線機設定画面で再設定などが前提となるので、一定間隔の送受信機能は画面からの再実行要求が行われる。
