### PR TITLE
運用モードの送信リトライ対応、およびロックの改善

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -637,11 +637,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const shiftRx = dopplerRxBaseFreq.value - nowRxFreq;
     const shiftTx = dopplerTxBaseFreq.value - nowTxFreq;
     const baseSum = dopplerRxBaseFreq.value + dopplerTxBaseFreq.value;
-    // AppRendererLogger.debug(
-    //   `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
-    //     ` シフト補正値： ${shiftRx} ${shiftTx}` +
-    //     ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
-    // );
+    AppRendererLogger.debug(
+      `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
+        ` シフト補正値： ${shiftRx} ${shiftTx}` +
+        ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
+    );
   }
 
   onMounted(async () => {

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -637,11 +637,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const shiftRx = dopplerRxBaseFreq.value - nowRxFreq;
     const shiftTx = dopplerTxBaseFreq.value - nowTxFreq;
     const baseSum = dopplerRxBaseFreq.value + dopplerTxBaseFreq.value;
-    AppRendererLogger.debug(
-      `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
-        ` シフト補正値： ${shiftRx} ${shiftTx}` +
-        ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
-    );
+    // AppRendererLogger.debug(
+    //   `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
+    //     ` シフト補正値： ${shiftRx} ${shiftTx}` +
+    //     ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
+    // );
   }
 
   onMounted(async () => {


### PR DESCRIPTION
#149 の対応。

■事象
- RSTでのモード変更が無線機に反映されない場合がある。
- AutoOn時の無線機更新間隔を0.1秒にした場合、且つTx側のモード変更において顕著である。

■原因
【補足】
- 周波数の更新のため、メイン、サブのバンドの切り替えを行うが、切り替えを行うと無線機からモードのトランシーブが発生する。
- トランシーブを受け取った場合、RSTは無線機からのモード変更が発生したものとする必要がある。

以下の複数の挙動により、画面でのモードが無線機に反映されず、画面にも意図しないモードが表示された。
①RSTの画面でのモード変更に基づき、無線機へモードを送信するが、その送信が完了する間に（変更前の古い）モードトランシーブが発生した場合、画面側へ変更前のモードが反映される。画面は設定前の古いモードの変更を再度無線機へ送信する。
②バンド切り替えの変更に関せずトランシーブ→画面反映が行われていた。
③無線機へのコマンド送信が失敗している。（その場合、設定に対する応答トランシーブが発生しない）

■対応
上記原因②③に対応。
- 無線機への運用モード送信時、無線機からのコマンド応答がない場合、セットに失敗したものとみなし、リトライするように修正。
- 無線機へのコマンド送信時などにおけるロック取得の改善。

原因①の対応が未完であるが動作はかなり改善した。
