### PR TITLE
無線機のAutoOnの状態でもレーダー部のダブルクリックでローテータ移動を可能とする

### DIFF
--- a/src/renderer/components/organisms/Radar/useCanvasPosToAntennaPos.ts
+++ b/src/renderer/components/organisms/Radar/useCanvasPosToAntennaPos.ts
@@ -24,7 +24,7 @@ export default function useCanvasPosToAntennaPos(canvasRef: Ref<HTMLCanvasElemen
     }
 
     // Auto状態の場合はレーダ部クリックは無効
-    if (autoStore.isAutoMode()) {
+    if (autoStore.isRotatorAutoMode()) {
       return;
     }
 

--- a/src/renderer/store/useStoreAutoState.ts
+++ b/src/renderer/store/useStoreAutoState.ts
@@ -12,11 +12,21 @@ export const useStoreAutoState = defineStore(
     // ローテータのAuto状態
     const rotatorAuto = ref(false);
 
+    /**
+     * 無線機とローテータのいずれかがAutoOnか判定する
+     */
     function isAutoMode() {
       return rotatorAuto.value || tranceiverAuto.value;
     }
 
-    return { rotatorAuto, tranceiverAuto, isAutoMode };
+    /**
+     * ローテータがAutoOnか判定する
+     */
+    function isRotatorAutoMode() {
+      return rotatorAuto.value;
+    }
+
+    return { rotatorAuto, tranceiverAuto, isAutoMode, isRotatorAutoMode };
   },
   {
     // 再起動時の状態の保持は不要


### PR DESCRIPTION
レーダー部のダブルクリックでアンテナを当該位置に移動する。
ただし、無線機、またはローテータのAutoがOn状態の場合は、移動は無効としていた。
これを無線機のAutoOn状態は無視し、ローテータのAutoOn状態のみで判定するように修正。