### PR TITLE
v0.1.4c

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ VsCodeでのデバッグ実行の方法です。
 #### アイコン編集
 
 Inkscapeで編集を行う。
-小さいアイコン向け
-　public\assets\アイコン\_24.svg
-大きいアイコン向け
-　public\assets\アイコン\_512.svg
+- 小さいアイコン向け
+    - public\assets\アイコン\_24.svg
+- 大きいアイコン向け
+    - public\assets\アイコン\_512.svg
 
 #### Windows向けのicoの作成
 
-複数pngをicoファイルに格納するため、以下からImageMagicをダウンロード、インストールする。
+複数pngをicoファイルに格納するため、以下からImageMagicをダウンロード、インストールする。    
 https://www.imagemagick.org/script/download.php
 
 以下をコマンドプロンプトで実行する。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rst",
   "productName": "RST",
   "private": true,
-  "version": "v0.1.4b",
+  "version": "v0.1.4c",
   "author": {
     "name": "rsp.",
     "email": "xxx@rymansat.com"

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -2,7 +2,7 @@
  * 定数
  */
 export default class Constant {
-  public static readonly appVersion = "v0.1.4b";
+  public static readonly appVersion = "v0.1.4c";
 
   /**
    * ロガー関係

--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -278,7 +278,7 @@ export default class I18nMsgs {
   public static readonly G41_MAKER: I18nMsgItem = { en: "Maker", ja: "メーカー" };
   public static readonly G41_DEVICE: I18nMsgItem = { en: "Device", ja: "機種" };
   public static readonly G41_SERIAL_PORT: I18nMsgItem = { en: "Serial Port", ja: "シリアルポート" };
-  public static readonly G41_BORATE: I18nMsgItem = { en: "Borate", ja: "ボーレート" };
+  public static readonly G41_BORATE: I18nMsgItem = { en: "Baud Rate", ja: "ボーレート" };
   public static readonly G41_CIVADDRESS: I18nMsgItem = { en: "CI-V Address", ja: "CI-Vアドレス" };
   public static readonly G41_TEST_CONNECT: I18nMsgItem = { en: "Test Connect", ja: "接続テスト" };
   public static readonly G41_IPADDRESS: I18nMsgItem = { en: "IP Address", ja: "IPアドレス" };
@@ -294,7 +294,7 @@ export default class I18nMsgs {
   public static readonly G51_MAKER: I18nMsgItem = { en: "Maker", ja: "メーカー" };
   public static readonly G51_DEVICE: I18nMsgItem = { en: "Device", ja: "機種" };
   public static readonly G51_SERIAL_PORT: I18nMsgItem = { en: "Serial Port", ja: "シリアルポート" };
-  public static readonly G51_BORATE: I18nMsgItem = { en: "Borate", ja: "ボーレート" };
+  public static readonly G51_BORATE: I18nMsgItem = { en: "Baud Rate", ja: "ボーレート" };
   public static readonly G51_TEST_CONNECT: I18nMsgItem = { en: "Test Connect", ja: "接続テスト" };
   public static readonly G51_TEST_MODE: I18nMsgItem = { en: "Test Mode", ja: "テストモード" };
   public static readonly G51_IPADDRESS: I18nMsgItem = { en: "IP Address", ja: "IPアドレス" };
@@ -319,7 +319,7 @@ export default class I18nMsgs {
   };
   public static readonly G51_PARK_POS: I18nMsgItem = { en: "Park position", ja: "パークポジション" };
   // 画面項目系／衛星設定画面
-  public static readonly G31_DISPLAY_SATELLITE: I18nMsgItem = { en: "Display Sattelite", ja: "表示衛星" };
+  public static readonly G31_DISPLAY_SATELLITE: I18nMsgItem = { en: "Display Satellite", ja: "表示衛星" };
   public static readonly G32_TLE_LOAD: I18nMsgItem = { en: "TLE Load", ja: "TLE読み込み" };
   public static readonly G33_OTHER_SETTING: I18nMsgItem = { en: "Others", ja: "その他設定" };
   // 画面項目系／衛星設定画面 表示衛星
@@ -334,7 +334,7 @@ export default class I18nMsgs {
   public static readonly G31_TONE: I18nMsgItem = { en: "Tone Freq.", ja: "トーン周波数" };
   public static readonly G31_OUTLINE: I18nMsgItem = { en: "Outline", ja: "概要" };
   public static readonly G31_MANUAL_SET: I18nMsgItem = { en: "Manual", ja: "マニュアル設定" };
-  public static readonly G31_BEACON: I18nMsgItem = { en: "Tone Freq.", ja: "ビーコン周波数" };
+  public static readonly G31_BEACON: I18nMsgItem = { en: "Beacon Freq.", ja: "ビーコン周波数" };
   public static readonly G31_NORMAL: I18nMsgItem = { en: "Normal", ja: "ノーマル" };
   public static readonly G31_REVERSE: I18nMsgItem = { en: "Reverse", ja: "リバース" };
 

--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -131,6 +131,10 @@ export default class I18nMsgs {
     en: "Uplink and Downlink frequencies are not set.",
     ja: "アップリンク周波数とダウンリンク周波数が設定されていません。",
   };
+  public static readonly NOTICE_UNDER_DEVELOPMENT: I18nMsgItem = {
+    en: "This feature is under development and cannot be used.",
+    ja: "この機能は実装中のため使用できません。",
+  };
 
   // AppConfig系エラーメッセージ
   public static readonly CHK_ERR_APPCONFIG_NOT_EXISTS_FILE: I18nMsgItem = {

--- a/src/renderer/components/organisms/Radar/useCanvasPosToAntennaPos.ts
+++ b/src/renderer/components/organisms/Radar/useCanvasPosToAntennaPos.ts
@@ -24,7 +24,7 @@ export default function useCanvasPosToAntennaPos(canvasRef: Ref<HTMLCanvasElemen
     }
 
     // Auto状態の場合はレーダ部クリックは無効
-    if (autoStore.isAutoMode()) {
+    if (autoStore.isRotatorAutoMode()) {
       return;
     }
 

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -156,6 +156,7 @@ import DateTimePicker from "@/renderer/components/organisms/DateTimePicker/DateT
 import { useStoreAutoState } from "@/renderer/store/useStoreAutoState";
 import CanvasUtil from "@/renderer/util/CanvasUtil";
 import DateUtil from "@/renderer/util/DateUtil";
+import emitter from "@/renderer/util/EventBus";
 import { computed, ref, watch } from "vue";
 import useOrbitalPassList from "./useOrbitalPassList";
 import useOverlapPassList from "./useOverlapPassList";
@@ -242,6 +243,10 @@ async function satTrackingModeBtnClick(isNormal: boolean) {
  */
 async function beaconBtnClick() {
   isBeaconMode.value = !isBeaconMode.value;
+  // TODO: ビーコンモードを実装したら削除する
+  if (isBeaconMode.value) {
+    emitter.emit(Constant.GlobalEvent.NOTICE_ERR, I18nUtil.getMsg(I18nMsgs.NOTICE_UNDER_DEVELOPMENT));
+  }
 }
 /**
  * Rxのラベルをアクティブにするかどうか

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -637,11 +637,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const shiftRx = dopplerRxBaseFreq.value - nowRxFreq;
     const shiftTx = dopplerTxBaseFreq.value - nowTxFreq;
     const baseSum = dopplerRxBaseFreq.value + dopplerTxBaseFreq.value;
-    // AppRendererLogger.debug(
-    //   `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
-    //     ` シフト補正値： ${shiftRx} ${shiftTx}` +
-    //     ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
-    // );
+    AppRendererLogger.debug(
+      `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
+        ` シフト補正値： ${shiftRx} ${shiftTx}` +
+        ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
+    );
   }
 
   onMounted(async () => {

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -637,11 +637,11 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const shiftRx = dopplerRxBaseFreq.value - nowRxFreq;
     const shiftTx = dopplerTxBaseFreq.value - nowTxFreq;
     const baseSum = dopplerRxBaseFreq.value + dopplerTxBaseFreq.value;
-    AppRendererLogger.debug(
-      `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
-        ` シフト補正値： ${shiftRx} ${shiftTx}` +
-        ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
-    );
+    // AppRendererLogger.debug(
+    //   `ドップラーシフト補正後: ${nowRxFreq} ${nowTxFreq}` +
+    //     ` シフト補正値： ${shiftRx} ${shiftTx}` +
+    //     ` 基準周波数: ${dopplerRxBaseFreq.value} ${dopplerTxBaseFreq.value} = ${baseSum}`
+    // );
   }
 
   onMounted(async () => {

--- a/src/renderer/store/useStoreAutoState.ts
+++ b/src/renderer/store/useStoreAutoState.ts
@@ -12,11 +12,21 @@ export const useStoreAutoState = defineStore(
     // ローテータのAuto状態
     const rotatorAuto = ref(false);
 
+    /**
+     * 無線機とローテータのいずれかがAutoOnか判定する
+     */
     function isAutoMode() {
       return rotatorAuto.value || tranceiverAuto.value;
     }
 
-    return { rotatorAuto, tranceiverAuto, isAutoMode };
+    /**
+     * ローテータがAutoOnか判定する
+     */
+    function isRotatorAutoMode() {
+      return rotatorAuto.value;
+    }
+
+    return { rotatorAuto, tranceiverAuto, isAutoMode, isRotatorAutoMode };
   },
   {
     // 再起動時の状態の保持は不要


### PR DESCRIPTION
以下に対応。
- ICOM無線機における運用モードの変更設定の改善
- 英語表記の誤記修正
- 無線機のAutoOnの状態でもレーダー部のダブルクリックでローテータ移動を可能とする
- ビーコンモードが実装中で使えない旨をメッセージ表示
