### PR TITLE
無線機操作後ドップラーシフト開始時間を追加（現在は非活性）

### DIFF
--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -292,6 +292,10 @@ export default class I18nMsgs {
     en: "Auto-Tracking Start/End Time",
     ja: "自動追尾準備・終了時間",
   };
+  public static readonly G41_DOPPLER_RESUME_DELAY: I18nMsgItem = {
+    en: "Doppler Resume Delay",
+    ja: "無線機操作後ドップラーシフト再開時間",
+  };
   // 画面項目系／ローテータ設定画面
   public static readonly G51_TAB_CONNECTION: I18nMsgItem = { en: "Device", ja: "機種設定" };
   public static readonly G51_TAB_BEHIVIOR: I18nMsgItem = { en: "Behivior", ja: "動作設定" };

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -175,6 +175,8 @@ export class AppConfigTransceiver {
   public autoTrackingIntervalSec = "1";
   // 自動追尾準備・終了時間（分）
   public autoTrackingStartEndTime = "1";
+  // 無線機操作後ドップラーシフト再開時間（秒）
+  public dopplerResumeDelaySec = "1";
   // 無線機の送信周波数
   public txFrequency = "2430.000.000";
   // 無線機の受信周波数

--- a/src/common/model/AppConfigModel.ts
+++ b/src/common/model/AppConfigModel.ts
@@ -176,7 +176,7 @@ export class AppConfigTransceiver {
   // 自動追尾準備・終了時間（分）
   public autoTrackingStartEndTime = "1";
   // 無線機操作後ドップラーシフト再開時間（秒）
-  public dopplerResumeDelaySec = "1";
+  public dopplerResumeDelaySec = "2";
   // 無線機の送信周波数
   public txFrequency = "2430.000.000";
   // 無線機の受信周波数

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverBegavior/TransceiverBegavior.vue
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverBegavior/TransceiverBegavior.vue
@@ -31,6 +31,22 @@
             />
           </div>
         </div>
+        <!-- 無線機操作後ドップラーシフト再開時間 -->
+        <div class="d-flex mt-2">
+          <label class="label form_label">{{ I18nUtil.getMsg(I18nMsgs.G41_DOPPLER_RESUME_DELAY) }}</label>
+          <div class="form_select ml-2">
+            <!-- TODO main側の処理ができるまで非活性 -->
+            <v-select
+              v-model="form.dopplerResumeDelaySec"
+              :items="doppleResumeDelaySecOptions"
+              hide-details
+              variant="outlined"
+              density="compact"
+              class="selectbox"
+              :disabled="true"
+            />
+          </div>
+        </div>
       </div>
     </v-col>
 
@@ -53,6 +69,9 @@ const autoTrackingIntervalSecOptions = ["0.1", "0.5", "1", "2", "3", "4", "5", "
 });
 const autoTrackingStartEndTimeOptions = Array.from({ length: 15 }, (_, i) => String(i + 1)).map((item) => {
   return { title: `${item} min`, value: item };
+});
+const doppleResumeDelaySecOptions = Array.from({ length: 9 }, (_, i) => String(i + 1)).map((item) => {
+  return { title: `${item} sec`, value: item };
 });
 </script>
 

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverBegavior/TransceiverBegaviorForm.ts
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverBegavior/TransceiverBegaviorForm.ts
@@ -6,4 +6,6 @@ export default class TransceiverBegaviorForm {
   public autoTrackingIntervalSec = "";
   // 自動追尾準備・終了時間 (分)
   public autoTrackingStartEndTime = "";
+  // 無線機操作後ドップラーシフト再開時間 (秒)
+  public dopplerResumeDelaySec = "";
 }

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverSetting.vue
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverSetting.vue
@@ -65,7 +65,7 @@ const form = ref<TransceiverSettingForm>(new TransceiverSettingForm());
 
 // 制御系データ
 // ダイアログの表示可否
-const isShow = defineModel("isShow");
+const isShow = defineModel<boolean>("isShow");
 const loadingTestBtn = ref(false);
 const isSerialOpen = ref(false);
 const refTravsceiverConn = ref();

--- a/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverSettingForm.ts
+++ b/src/renderer/components/organisms/setting/TransceiverSetting/TransceiverSettingForm.ts
@@ -9,4 +9,6 @@ export default class TransceiverSettingForm extends TransceiverConnForm {
   public autoTrackingIntervalSec = "";
   // 自動追尾準備・終了時間 (分)
   public autoTrackingStartEndTime = "";
+  // 無線機操作後ドップラーシフト再開時間 (秒)
+  public dopplerResumeDelaySec = "";
 }


### PR DESCRIPTION
# 前提
- 項目追加要請あり

# 実装概要
- 無線機設定の動作設定に「無線機操作後ドップラーシフト開始時間」のプルダウンを追加
- 1〜10秒を指定可能

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/275f7402-161f-473b-8f6c-9cebcd5279fd" />

# 注意点
- 現在はサーバ側の処理がないので非活性
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/25ffef9e-928e-405d-a0df-d32a76f218b3" />

# 関連
- なし