### PR TITLE
衛星名の変更をメイン画面のリストに反映

### DIFF
--- a/src/renderer/common/util/ActiveSatHelper.ts
+++ b/src/renderer/common/util/ActiveSatHelper.ts
@@ -3,7 +3,6 @@ import { AppConfigSatellite } from "@/common/model/AppConfigModel";
 import TleUtil from "@/main/util/TleUtil";
 import ApiAppConfig from "@/renderer/api/ApiAppConfig";
 import ApiAppConfigSatellite from "@/renderer/api/ApiAppConfigSatellite";
-import ApiDefaultSatellite from "@/renderer/api/ApiDefaultSatellite";
 import ApiTle from "@/renderer/api/ApiTle";
 
 /**
@@ -45,7 +44,7 @@ export default class ActiveSatHelper {
       }
 
       // ユーザ設定衛星でない場合
-      sats.push(await this.getSatByDefault(satId));
+      sats.push(await this.getSatByAppConfig(sat));
     }
 
     return sats;
@@ -70,19 +69,18 @@ export default class ActiveSatHelper {
   }
 
   /**
-   * デフォルト衛星から衛星情報を取得する
+   * ユーザ設定衛星情報を取得する
    */
-  private static async getSatByDefault(satId: number): Promise<ActiveSatelliteModel> {
+  private static async getSatByAppConfig(sat: AppConfigSatellite): Promise<ActiveSatelliteModel> {
     const satModel = new ActiveSatelliteModel();
-    satModel.satelliteId = satId;
-
-    const defalutSat = await ApiDefaultSatellite.getDefaultSatelliteBySatelliteId(satId);
+    satModel.satelliteId = sat.satelliteId;
 
     // 衛星名
-    satModel.satelliteName = defalutSat.satelliteName;
+    // ユーザ設定がない場合はdefaultSatの衛星名がここに入っている
+    satModel.satelliteName = sat.userRegisteredSatelliteName;
 
     // TLEはNorad IDから取得
-    const tles = await ApiTle.getTlesByNoradIds([defalutSat.noradId]);
+    const tles = await ApiTle.getTlesByNoradIds([sat.noradId]);
     satModel.tle = tles[0];
 
     return satModel;

--- a/src/renderer/common/util/ActiveSatHelper.ts
+++ b/src/renderer/common/util/ActiveSatHelper.ts
@@ -39,7 +39,7 @@ export default class ActiveSatHelper {
 
       // ユーザ設定衛星の場合
       if (sat.userRegistered) {
-        sats.push(this.getSatByUserReg(satId, sat));
+        sats.push(this.getSatByUserReg(sat));
         continue;
       }
 
@@ -53,9 +53,9 @@ export default class ActiveSatHelper {
   /**
    * ユーザ設定衛星情報を取得する
    */
-  private static getSatByUserReg(satId: number, sat: AppConfigSatellite): ActiveSatelliteModel {
+  private static getSatByUserReg(sat: AppConfigSatellite): ActiveSatelliteModel {
     const satModel = new ActiveSatelliteModel();
-    satModel.satelliteId = satId;
+    satModel.satelliteId = sat.satelliteId;
 
     // 衛星名
     satModel.satelliteName = sat.userRegisteredSatelliteName;

--- a/src/renderer/common/util/ActiveSatHelper.ts
+++ b/src/renderer/common/util/ActiveSatHelper.ts
@@ -70,6 +70,7 @@ export default class ActiveSatHelper {
 
   /**
    * ユーザ設定衛星情報を取得する
+   * ユーザ設定がない場合は自動的にデフォルト衛星の情報が入る
    */
   private static async getSatByAppConfig(sat: AppConfigSatellite): Promise<ActiveSatelliteModel> {
     const satModel = new ActiveSatelliteModel();


### PR DESCRIPTION
# 前提
- 衛星名を変更してもメイン画面のリストに反映されない
  - TLEから取得した衛星の場合にデフォルト設定の衛星名を表示していた

# 実装概要
- ApiAppConfigSatellite.getUserRegisteredAppConfigSatelliteは今appConfigから取得しているのか、defaultSatから取得しているのかを意識しなくてもいいようにしている
- 利用側で衛星名を取得する場合は単にuserRegisteredSatelliteNameを使えばいい
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/4fe01d92-e64f-4cdc-8641-35402a33ae76" />

# 注意点
 なし

# 関連
#185 