### PR TITLE
周波数の上限制御とグレーアウト挙動の修正

### DIFF
--- a/src/__tests__/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.test.ts
+++ b/src/__tests__/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.test.ts
@@ -158,4 +158,17 @@ describe("useFrequencySelect", () => {
       expect(isGrayedAt3).toBe(false);
     });
   });
+
+  it("全ての桁が0の時は最下位桁はグレーにしない", () => {
+    // Arrange
+    const { controller } = createSut("+000.000");
+
+    // Act
+    const isGrayedAt0 = controller.isGrayed(0);
+    const isGrayedAt5 = controller.isGrayed(5);
+
+    // Assert
+    expect(isGrayedAt0).toBe(true);
+    expect(isGrayedAt5).toBe(false);
+  });
 });

--- a/src/__tests__/renderer/util/FrequencyUtil.test.ts
+++ b/src/__tests__/renderer/util/FrequencyUtil.test.ts
@@ -111,8 +111,76 @@ describe("FrequencyUtil", () => {
       // Arrange
       const digits = [1, 2, 3, 4];
 
-      // Act / Assert
-      expect(() => FrequencyUtil.formatFrequency(digits)).toThrow("digits length must be a multiple of 3");
+      // Act
+      const action = () => FrequencyUtil.formatFrequency(digits);
+
+      // Assert
+      expect(action).toThrow("digits length must be a multiple of 3");
+    });
+  });
+
+  describe("isCarryable", () => {
+    it.each([
+      { caseName: "指定桁が9未満", digits: [2, 4, 3, 0, 0, 0], index: 2, expected: true },
+      { caseName: "9が連続しても上位桁で繰り上がれる", digits: [2, 9, 9], index: 2, expected: true },
+      { caseName: "全桁9で最上位まで繰り上がる", digits: [9, 9, 9], index: 2, expected: false },
+      { caseName: "最上位桁が9", digits: [9, 0, 0], index: 0, expected: false },
+    ])("$caseName のとき繰り上がり可否を判定できる", ({ digits, index, expected }) => {
+      // Arrange
+
+      // Act
+      const carryable = FrequencyUtil.isCarryable(digits, index);
+
+      // Assert
+      expect(carryable).toBe(expected);
+    });
+
+    it("indexが負数の場合は例外を投げる", () => {
+      // Arrange
+      const digits = [2, 4, 3];
+
+      // Act
+      const action = () => FrequencyUtil.isCarryable(digits, -1);
+
+      // Assert
+      expect(action).toThrow("Index must be non-negative");
+    });
+
+    it.each([
+      { caseName: "NaN", index: Number.NaN },
+      { caseName: "Infinity", index: Number.POSITIVE_INFINITY },
+      { caseName: "小数", index: 1.5 },
+    ])("indexが$caseNameの場合は例外を投げる", ({ index }) => {
+      // Arrange
+      const digits = [2, 4, 3];
+
+      // Act
+      const action = () => FrequencyUtil.isCarryable(digits, index);
+
+      // Assert
+      expect(action).toThrow("Index must be a finite integer");
+    });
+
+    it("indexが配列範囲外の場合は例外を投げる", () => {
+      // Arrange
+      const digits = [2, 4, 3];
+
+      // Act
+      const action = () => FrequencyUtil.isCarryable(digits, 3);
+
+      // Assert
+      expect(action).toThrow("Index must be within digits range");
+    });
+
+    it("digitsが空配列の場合は例外を投げる", () => {
+      // Arrange
+      const digits: number[] = [];
+
+      // Act
+      const action = () => FrequencyUtil.isCarryable(digits, 0);
+
+      // Assert
+      expect(action).toThrow("Index must be within digits range");
     });
   });
 });

--- a/src/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.ts
+++ b/src/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.ts
@@ -105,6 +105,12 @@ const useFrequencySelect = (frequency: Ref<string>) => {
   function isGrayed(index: number) {
     const newDigits = [...kHzDigits.value, ...hzDigits.value];
     const idx = newDigits.findIndex((digit) => digit !== 0);
+
+    // 全ての桁が0の場合は最後の桁以外をグレーアウト
+    const everyDigitIsZero = newDigits.every((digit) => digit === 0);
+    const isIndexLast = index === newDigits.length - 1;
+    if (everyDigitIsZero) return !isIndexLast;
+
     // 0の場合は全てグレーアウト
     const firstNonZeroIndex = idx !== -1 ? idx : newDigits.length;
     return index < firstNonZeroIndex;

--- a/src/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.ts
+++ b/src/renderer/components/molecules/FreqAdjustmentSelect/useFreqAdjustmentSelect.ts
@@ -36,6 +36,11 @@ const useFrequencySelect = (frequency: Ref<string>) => {
 
     if ((event.deltaY < 0 && sign.value === 1) || (event.deltaY > 0 && sign.value === -1)) {
       // digit部分が増えるケース：符号がプラスでホイールを上に回した場合 or 符号がマイナスでホイールを下に回した場合
+
+      // 繰り上がりできない場合は変更しない
+      if (!FrequencyUtil.isCarryable(newDigits, index)) return frequency.value;
+
+      // 繰り上がりが可能の場合はホイールイベントの変更値を加算する
       newDigits[index] = (newDigits[index] + 1) % 10;
       for (let i = index; i > 0; i--) {
         if (newDigits[i] === 0) {

--- a/src/renderer/components/molecules/FrequencySelect/useFrequencySelect.ts
+++ b/src/renderer/components/molecules/FrequencySelect/useFrequencySelect.ts
@@ -1,3 +1,4 @@
+import { FrequencyUtil } from "@/renderer/util/FrequencyUtil";
 import { computed, ref, type Ref } from "vue";
 
 /**
@@ -47,6 +48,10 @@ const useFrequencySelect = (frequency: Ref<string>) => {
     const newDigits = [...mHzDigits.value, ...kHzDigits.value, ...hzDigits.value];
     if (event.deltaY < 0) {
       // ホイールを上に回した場合
+      // 繰り上がりできない場合は変更しない
+      if (!FrequencyUtil.isCarryable(newDigits, index)) return frequency.value;
+
+      // 繰り上がりが可能の場合はホイールイベントの変更値を加算する
       newDigits[index] = (newDigits[index] + 1) % 10;
       for (let i = index; i > 0; i--) {
         if (newDigits[i] === 0) {

--- a/src/renderer/util/FrequencyUtil.ts
+++ b/src/renderer/util/FrequencyUtil.ts
@@ -57,4 +57,28 @@ export class FrequencyUtil {
     }
     return parts.join(".");
   }
+
+  /**
+   * 指定したインデックスで繰り上がりが可能かどうかを判定する
+   * @param {number[]} digits - 周波数の各桁を表す数値の配列
+   * @param {number} index - 繰り上がりを判定するインデックス
+   * @returns {boolean} 繰り上がりが可能かどうか
+   * 例: digits = [2, 4, 3, 0, 0, 0], index = 2 -> true (3の次は4になるので繰り上がり可能)
+   */
+  public static isCarryable(digits: number[], index: number): boolean {
+    if (!Number.isFinite(index) || !Number.isInteger(index)) {
+      throw new Error("Index must be a finite integer");
+    }
+    if (index < 0) {
+      throw new Error("Index must be non-negative");
+    }
+    if (index >= digits.length) {
+      throw new Error("Index must be within digits range");
+    }
+    // 指定したインデックスから上位桁に向かって、9未満の桁があるかどうかを確認する
+    for (let i = index; i >= 0; i--) {
+      if (digits[i] < 9) return true;
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
# 前提
- 周波数は上限がなく繰り上がると最終的には0に戻るような動きだった
- 0になると全てグレーアウトされて非活性のように見えてしまう 

# 実装概要
- 最上位桁から9以上はカウントアップしないように変更
- 全て0の場合は最下位桁をグレーアウトしない 

<img width="230" height="301" alt="スクリーンショット 2026-03-18 6 57 52" src="https://github.com/user-attachments/assets/aa304237-868f-4b62-bfed-90ff6f3f4c9f" />

https://github.com/user-attachments/assets/a35ac1e0-3924-4681-bf69-bf9a51d8d856

# 注意点
- なし
 
# 関連
#186 #191 