### PR TITLE
衛星設定のフィルタをNORADIDでも可能にする

### DIFF
--- a/src/__tests__/main/validator/util/AppConfigUtil.test.ts
+++ b/src/__tests__/main/validator/util/AppConfigUtil.test.ts
@@ -33,7 +33,11 @@ test("success_transformSatelliteGroupsForSatSetting", () => {
 test("success_transformSatelliteGroups", () => {
   const appConfigSatSet = new AppConfigSatSettingModel();
   appConfigSatSet.satelliteGroupsForSatSetting = [
-    { groupId: 1, groupName: "group", satellites: [{ satelliteId: 1, satelliteName: "hoge", userRegistered: false }] },
+    {
+      groupId: 1,
+      groupName: "group",
+      satellites: [{ satelliteId: 1, satelliteName: "hoge", userRegistered: false, noradId: "12345" }],
+    },
   ];
   const appConfig = AppConfigUtil.transformSatelliteGroups(appConfigSatSet);
 

--- a/src/common/I18nMsgs.ts
+++ b/src/common/I18nMsgs.ts
@@ -333,6 +333,7 @@ export default class I18nMsgs {
   // 画面項目系／衛星設定画面 表示衛星
   public static readonly G31_SATELLITE_GROUP: I18nMsgItem = { en: "Satellite Group", ja: "衛星グループ" };
   public static readonly G31_GROUP: I18nMsgItem = { en: "Group", ja: "グループ" };
+  public static readonly G31_SEARCH: I18nMsgItem = { en: "Satellite Name/ NORAD ID", ja: "衛星名/NORAD ID" };
   // 画面項目系／衛星設定画面　衛星情報編集
   public static readonly G31_INTERNATIONAL_NAME: I18nMsgItem = { en: "International Name", ja: "国際呼称" };
   public static readonly G31_NORADID: I18nMsgItem = { en: "NORAD ID", ja: "NORAD ID" };

--- a/src/common/model/DefaultSatelliteModel.ts
+++ b/src/common/model/DefaultSatelliteModel.ts
@@ -68,6 +68,7 @@ export class DefaultSatelliteModel {
         satelliteId: defsat.satelliteId,
         satelliteName: defsat.satelliteName,
         userRegistered: false,
+        noradId: defsat.noradId,
       });
     });
     return satIdTypes;

--- a/src/common/types/satelliteSettingTypes.ts
+++ b/src/common/types/satelliteSettingTypes.ts
@@ -6,6 +6,7 @@ export type SatelliteIdentiferType = {
   satelliteId: number;
   satelliteName: string;
   userRegistered: boolean;
+  noradId: string;
 };
 
 /**

--- a/src/main/util/AppConfigUtil.ts
+++ b/src/main/util/AppConfigUtil.ts
@@ -427,7 +427,7 @@ export class AppConfigUtil {
           // 返却に必要な衛星IDと衛星名の組み合わせにする
           if (appConfigSat === null) {
             // ないはずだが衛星IDがヒットしなければundefined
-            return { satelliteId: satelliteId, satelliteName: "undefined", userRegistered: false };
+            return { satelliteId: satelliteId, satelliteName: "undefined", userRegistered: false, noradId: "" };
           } else {
             // デフォルト衛星が取得できたらその情報を返すが
             // ユーザ登録した衛星名があったらそちらを優先する
@@ -435,6 +435,7 @@ export class AppConfigUtil {
               satelliteId: appConfigSat.satelliteId,
               satelliteName: appConfigSat.userRegisteredSatelliteName,
               userRegistered: appConfigSat.userRegistered,
+              noradId: appConfigSat.noradId,
             };
           }
         })

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/EditSatelliteInfo/EditSatelliteInfo.vue
@@ -296,7 +296,7 @@ const isShow = defineModel<boolean>("isShow", {
 });
 // 親からもらう衛星識別情報
 const selectedItem = defineModel<SatelliteIdentiferType>("selectedItem", {
-  default: {},
+  default: { satelliteId: -1, satelliteName: "", userRegistered: false, noradId: "" },
 });
 // 衛星追加用の親のグループ
 const selectedGroupId = defineModel<number>("selectedGroupId", {

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/FilterableItemList/FilterableItemList.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/FilterableItemList/FilterableItemList.vue
@@ -3,7 +3,11 @@
   <div>
     <v-row>
       <v-col>
-        <TextField v-model="filterText" :label="I18nUtil.getMsg(I18nMsgs.GCOM_SEARCH)"></TextField>
+        <TextField
+          v-model="filterText"
+          :label="I18nUtil.getMsg(I18nMsgs.GCOM_SEARCH)"
+          :placeholder="I18nUtil.getMsg(I18nMsgs.G31_SEARCH)"
+        ></TextField>
       </v-col>
     </v-row>
     <v-row>
@@ -11,7 +15,7 @@
         <VirtualScrollList
           style="overflow-y: auto"
           :items="filteredItems"
-          :itemName="'satelliteName'"
+          :itemName="'displayText'"
           :itemKey="'satelliteId'"
           :height="355"
           :selectMode="'inclusive'"
@@ -41,6 +45,14 @@ import EditSatelliteInfo from "@/renderer/components/organisms/setting/Satellite
 import AppRendererLogger from "@/renderer/util/AppRendererLogger";
 import { computed, onMounted, ref } from "vue";
 
+type DisplaySatelliteItem = {
+  satelliteId: number;
+  satelliteName: string;
+  userRegistered: boolean;
+  noradId: string;
+  displayText: string;
+};
+
 // 衛星情報編集画面表示用のフラグ
 const enableEditSatelliteInfo = ref(false);
 // 衛星情報編集画面に表示用の選択されたアイテム
@@ -48,7 +60,7 @@ const selectedEditSatelliteItem = ref<SatelliteIdentiferType>();
 // フィルタテキスト
 const filterText = ref("");
 // リストに表示するアイテム
-const items = ref<SatelliteIdentiferType[]>([]);
+const items = ref<DisplaySatelliteItem[]>([]);
 // リストの関数を使用するためのref
 const listRef = ref<InstanceType<typeof VirtualScrollList> | null>(null);
 
@@ -60,7 +72,9 @@ onMounted(function () {
     .then((satIdentifer: SatelliteIdentiferType[]) => {
       if (satIdentifer) {
         // 衛星名でソートして値を格納する
-        items.value = satIdentifer.sort((a, b) => a.satelliteName.localeCompare(b.satelliteName));
+        items.value = satIdentifer
+          .map((item) => ({ ...item, displayText: `<${item.noradId}> ${item.satelliteName}` }))
+          .sort((a, b) => a.satelliteName.localeCompare(b.satelliteName));
       }
     })
     .catch((error) => {
@@ -76,7 +90,7 @@ const filteredItems = computed(function () {
   if (!filterText.value) {
     ret = items.value;
   } else {
-    ret = items.value.filter((item) => item.satelliteName.toLowerCase().includes(filterText.value.toLowerCase()));
+    ret = items.value.filter((item) => item.displayText.toLowerCase().includes(filterText.value.toLowerCase()));
   }
 
   return ret;

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
@@ -254,6 +254,7 @@ async function onOk() {
         satelliteId: apiSat.satelliteId,
         satelliteName: apiSat.userRegisteredSatelliteName,
         userRegistered: true,
+        noradId: apiSat.noradId,
       });
     }
   } else {

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/RegistSatellite/RegistSatellite.vue
@@ -180,7 +180,7 @@ const isShow = defineModel<boolean>("isShow", {
 });
 // 親画面で選択した衛星
 const selectedSatelliteItem = defineModel<SatelliteIdentiferType>("selectedSatelliteItem", {
-  default: { satelliteId: -1, satelliteName: "" },
+  default: { satelliteId: -1, satelliteName: "", userRegistered: false, noradId: "" },
 });
 // 衛星追加用の親のグループ
 const selectedGroupId = defineModel<number>("selectedGroupId", {

--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/SelectControlledItemList/SelectControlledItemList.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/SelectControlledItemList/SelectControlledItemList.vue
@@ -106,14 +106,23 @@ import { mdiArrowDownBold, mdiArrowUpBold, mdiDelete } from "@mdi/js";
 // 衛星グループリスト
 const satelliteGroups = defineModel<AppConfigSatelliteGroupForSatSetting[]>("satelliteGroups", { default: [] });
 // 選択されたグループ
-const selectedGroup = ref({ groupName: "", groupId: -1, satellites: [] } as AppConfigSatelliteGroupForSatSetting);
+const selectedGroup = ref<AppConfigSatelliteGroupForSatSetting>({
+  groupName: "",
+  groupId: -1,
+  satellites: [],
+} as AppConfigSatelliteGroupForSatSetting);
 // グループに所属する衛星リスト
 const selectedSatellites = defineModel<SatelliteIdentiferType[]>("selectedSatellites", { default: [] });
 // 衛星リストから選択したアイテムのインデックス
 const selectedItemIndex = ref<number | null>(null);
 
 // 選択されたアイテム
-const selectedSatelliteItem = ref({ satelliteId: -1, satelliteName: "", userRegistered: false });
+const selectedSatelliteItem = ref<SatelliteIdentiferType>({
+  satelliteId: -1,
+  satelliteName: "",
+  userRegistered: false,
+  noradId: "",
+});
 // 衛星グループ画面表示用のフラグ
 const enableGroupSatellite = ref(false);
 // 衛星登録画面表示用のフラグ
@@ -234,7 +243,7 @@ function showRegistSatellite() {
   if (item) {
     selectedSatelliteItem.value = item;
   } else {
-    selectedSatelliteItem.value = { satelliteId: -1, satelliteName: "", userRegistered: false };
+    selectedSatelliteItem.value = { satelliteId: -1, satelliteName: "", userRegistered: false, noradId: "" };
   }
 }
 


### PR DESCRIPTION
# 前提
- 衛星設定のフィルタは衛星名のみだった
# 実装概要
- NORADIDを表示しフィルタ可能にした
<img width="450" height="320" alt="スクリーンショット 2026-03-20 6 50 25" src="https://github.com/user-attachments/assets/851a423e-4615-4a5e-ad07-839d002d5779" />

# 注意点
- なし
# 関連
- #180 