### PR TITLE
フィルタで<>文字列がヒットしてしまうので、衛星名とnoradidを明示的にフィルターするように修正

### DIFF
--- a/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/FilterableItemList/FilterableItemList.vue
+++ b/src/renderer/components/organisms/setting/SatelliteSetting/DisplaySatellite/FilterableItemList/FilterableItemList.vue
@@ -90,7 +90,9 @@ const filteredItems = computed(function () {
   if (!filterText.value) {
     ret = items.value;
   } else {
-    ret = items.value.filter((item) => item.displayText.toLowerCase().includes(filterText.value.toLowerCase()));
+    ret = items.value.filter((item) =>
+      (item.satelliteName + item.noradId).toLowerCase().includes(filterText.value.toLowerCase())
+    );
   }
 
   return ret;


### PR DESCRIPTION
# 前提
- フィルタは表示文字列でフィルタしていたため<>がヒットしていた

# 実装概要
- 衛星名とnoradidを明示的にフィルターするように修正
<img width="331" height="455" alt="スクリーンショット 2026-03-21 7 14 46" src="https://github.com/user-attachments/assets/dbb3bec9-7688-43fb-b120-e989633d113f" />


# 注意点
- なし

# 関連
- #180 