### PR TITLE
Rx、Tx周波数の補正値対応（補正値は基準周波数には適用しない）

### DIFF
--- a/src/__tests__/renderer/service/FrequencyTrackService_calcInvHeteroBaseFreqByRxFreq.test.ts
+++ b/src/__tests__/renderer/service/FrequencyTrackService_calcInvHeteroBaseFreqByRxFreq.test.ts
@@ -11,27 +11,17 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByRxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1000, 0, 500, 0.8);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1000, 500, 0.8);
 
     expect(rxBaseFreq).toBe(625); // 500 / 0.8 = 625
     expect(txBaseFreq).toBe(375); // 1000 - 625 = 375
-  });
-
-  it("逆ヘテロダウンでRx、Txの基準周波数を計算する（補正値あり）", () => {
-    const service = new FrequencyTrackService(
-      new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
-    );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1000, 1, 500, 0.8);
-
-    expect(rxBaseFreq).toBe(625); // 500 / 0.8 = 625
-    expect(txBaseFreq).toBe(374); // 1000 - 1 - 625 = 374
   });
 
   it("ドップラーファクターが1.0の場合", () => {
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1000, 0, 500, 1.0);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1000, 500, 1.0);
 
     expect(rxBaseFreq).toBe(500); // 500 / 1.0 = 500
     expect(txBaseFreq).toBe(500); // 1000 - 500 = 500
@@ -41,7 +31,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByRxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(2000, 0, 800, 1.2);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(2000, 800, 1.2);
 
     expect(rxBaseFreq).toBeCloseTo(667, 2); // 800 / 1.2 ≈ 666.667
     expect(txBaseFreq).toBeCloseTo(1333, 2); // 2000 - 666.667 ≈ 1333.333
@@ -51,7 +41,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByRxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1500, 0, 600, 0.6);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(1500, 600, 0.6);
 
     expect(rxBaseFreq).toBe(1000); // 600 / 0.6 = 1000
     expect(txBaseFreq).toBe(500); // 1500 - 1000 = 500
@@ -61,7 +51,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByRxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(145.5, 0, 70.25, 0.95);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(145.5, 70.25, 0.95);
 
     expect(rxBaseFreq).toBeCloseTo(74, 3); // 70.25 / 0.95 ≈ 73.947
     expect(txBaseFreq).toBeCloseTo(72, 3); // 145.5 - 73.947 ≈ 71.553
@@ -71,7 +61,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByRxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(0, 0, 0, 1.0);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByRxFreq(0, 0, 1.0);
 
     expect(rxBaseFreq).toBe(0); // 0 / 1.0 = 0
     expect(txBaseFreq).toBe(0); // 0 - 0 = 0

--- a/src/__tests__/renderer/service/FrequencyTrackService_calcInvHeteroBaseFreqByTxFreq.test.ts
+++ b/src/__tests__/renderer/service/FrequencyTrackService_calcInvHeteroBaseFreqByTxFreq.test.ts
@@ -11,27 +11,17 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByTxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1000, 0, 500, 0.8);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1000, 500, 0.8);
 
     expect(txBaseFreq).toBe(625); // 500 / 0.8 = 625
     expect(rxBaseFreq).toBe(375); // 1000 - 625 = 375
-  });
-
-  it("逆ヘテロダウンでRx、Txの基準周波数を計算する（補正値あり）", () => {
-    const service = new FrequencyTrackService(
-      new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
-    );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1000, 1, 500, 0.8);
-
-    expect(txBaseFreq).toBe(625); // 500 / 0.8 = 625
-    expect(rxBaseFreq).toBe(374); // 1000 - 1 - 625 = 374
   });
 
   it("ドップラーファクターが1.0の場合", () => {
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1000, 0, 500, 1.0);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1000, 500, 1.0);
 
     expect(txBaseFreq).toBe(500); // 500 / 1.0 = 500
     expect(rxBaseFreq).toBe(500); // 1000 - 500 = 500
@@ -41,7 +31,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByTxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(2000, 0, 800, 1.2);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(2000, 800, 1.2);
 
     expect(txBaseFreq).toBeCloseTo(667, 2); // 800 / 1.2 ≈ 666.667
     expect(rxBaseFreq).toBeCloseTo(1333, 2); // 2000 - 666.667 ≈ 1333.333
@@ -51,7 +41,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByTxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1500, 0, 600, 0.6);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(1500, 600, 0.6);
 
     expect(txBaseFreq).toBe(1000); // 600 / 0.6 = 1000
     expect(rxBaseFreq).toBe(500); // 1500 - 1000 = 500
@@ -61,7 +51,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByTxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(145.5, 0, 70.25, 0.95);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(145.5, 70.25, 0.95);
 
     expect(txBaseFreq).toBeCloseTo(74, 3); // 70.25 / 0.95 ≈ 73.947
     expect(rxBaseFreq).toBeCloseTo(72, 3); // Math.round(145.5) - 74 = 146 - 74 = 72
@@ -71,7 +61,7 @@ describe("FrequencyTrackService.calcInvHeteroBaseFreqByTxFreqのテスト", () =
     const service = new FrequencyTrackService(
       new SatelliteService({ tleLine1: "dummy", tleLine2: "dummy", satelliteName: "dummy" })
     );
-    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(0, 0, 0, 1.0);
+    const { rxBaseFreq, txBaseFreq } = service.calcInvHeteroBaseFreqByTxFreq(0, 0, 1.0);
 
     expect(txBaseFreq).toBe(0); // 0 / 1.0 = 0
     expect(rxBaseFreq).toBe(0); // 0 - 0 = 0

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -1039,13 +1039,15 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const activeSatHubService = ActiveSatServiceHub.getInstance();
     const setting = activeSatHubService.getActiveSatTransceiverSetting();
     if (!setting || !setting.downlink || !setting.uplink) {
-      return 0;
+      baseFreqSum.value = 0;
+      return baseFreqSum.value;
     }
 
     const downlinkHz = setting.downlink.downlinkHz;
     const uplinkHz = setting.uplink.uplinkHz;
     if (downlinkHz === null || uplinkHz === null) {
-      return 0;
+      baseFreqSum.value = 0;
+      return baseFreqSum.value;
     }
 
     baseFreqSum.value = downlinkHz + uplinkHz;

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -183,8 +183,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
     // Auto開始をメイン側に連携する
     await ApiTransceiver.transceiverInitAutoOn(
-      calcAdjustedRxFreq(),
       calcAdjustedTxFreq(),
+      calcAdjustedRxFreq(),
       txOpeMode.value,
       rxOpeMode.value,
       transceiverSetting.toneHz
@@ -959,7 +959,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
   /**
    * ドップラーシフトされたRx周波数を元に、Rx、Tx基準周波数を算出する
-   * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
+   * @param adjustFreq Rx補正値
    * @param shiftedAndAdjustedRxFreq ドップラー補正されたRx周波数（補正値適用済みの値）
    */
   async function calcBaseFreqByShiftedRxFreq(
@@ -980,10 +980,10 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     );
 
     // Rx、Txの基準周波数を更新する
-    const shiftedTxFreq = shiftedAndAdjustedRxFreq - adjustFreq;
+    const shiftedRxFreq = shiftedAndAdjustedRxFreq - adjustFreq;
     const { rxBaseFreq, txBaseFreq } = frequencyTrackService.calcInvHeteroBaseFreqByRxFreq(
       baseFreqNum,
-      shiftedTxFreq,
+      shiftedRxFreq,
       rxDopplerFactor
     );
 
@@ -992,7 +992,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
   /**
    * ドップラーシフトされたTx周波数を元に、Rx、Tx基準周波数を算出する
-   * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
+   * @param adjustFreq Tx補正値
    * @param shiftedAndAdjustedTxFreq ドップラー補正されたTx周波数（補正値適用済みの値）
    */
   async function calcBaseFreqByShiftedTxFreq(

--- a/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
+++ b/src/renderer/components/organisms/TransceiverCtrl/useTransceiverCtrl.ts
@@ -174,11 +174,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     dopplerTxBaseFreq.value = TransceiverUtil.parseNumber(txFrequency.value);
     dopplerRxBaseFreq.value = TransceiverUtil.parseNumber(rxFrequency.value);
 
-    // 画面の補正値で加減算した周波数を取得
-    const rxFreq = calcAdjustedRxFreq();
-    const txFreq = calcAdjustedTxFreq();
-
-    // 基準周波数の和を更新する（逆ヘテロダインの計算用、補正値を反映したもの）
+    // 基準周波数の和を更新する（逆ヘテロダインの計算用）
     calcBaseFreqSum();
 
     // ドップラーシフトのフラグを初期化
@@ -187,8 +183,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
 
     // Auto開始をメイン側に連携する
     await ApiTransceiver.transceiverInitAutoOn(
-      txFreq,
-      rxFreq,
+      calcAdjustedRxFreq(),
+      calcAdjustedTxFreq(),
       txOpeMode.value,
       rxOpeMode.value,
       transceiverSetting.toneHz
@@ -374,7 +370,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
    * アップリンク周波数を更新する
    * @param {number} newTxFrequency アップリンク周波数
    */
-  async function updateTxFreq(newTxFrequency: number) {
+  async function sendTxFreq(newTxFrequency: number) {
     await ApiTransceiver.setTransceiverFrequency({
       uplinkHz: newTxFrequency,
       uplinkMode: "",
@@ -385,7 +381,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
    * ダウンリンク周波数を更新する
    * @param {number} newRxFreq ダウンリンク周波数
    */
-  async function updateRxFreq(newRxFreq: number) {
+  async function sendRxFreq(newRxFreq: number) {
     await ApiTransceiver.setTransceiverFrequency({
       downlinkHz: newRxFreq,
       downlinkMode: "",
@@ -500,19 +496,16 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       TransceiverUtil.parseNumber(newFrequency),
       TransceiverUtil.parseNumber(txFrequencyAdjustment.value)
     );
-    await updateTxFreq(freq);
+    await sendTxFreq(freq);
   });
 
   /**
    * 画面でTx補正値が変更された場合
    */
   watch(txFrequencyAdjustment, async (newFreq) => {
-    // 基準周波数の和を更新する（逆ヘテロダインの計算用、補正値を反映したもの）
-    calcBaseFreqSum();
-
     // 補正値を反映した周波数を無線機に送信する
     const freq = calcAdjustedFreq(TransceiverUtil.parseNumber(txFrequency.value), TransceiverUtil.parseNumber(newFreq));
-    await updateTxFreq(freq);
+    await sendTxFreq(freq);
   });
 
   /**
@@ -531,7 +524,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   });
 
   /**
-   * Tx運用モードが変更された場合
+   * 画面でTx運用モードが変更された場合
    */
   watch(txOpeMode, async (newTxOpeMode) => {
     // 無線機にTx運用モードを設定する
@@ -542,7 +535,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   });
 
   /**
-   * Rx周波数が変更された場合
+   * 画面でRx周波数が変更された場合
    * TODO: SPLITモードの場合のサーバ処理がないので、今はSPLITモードの時は何もしない
    */
   watch(rxFrequency, async (newFreq) => {
@@ -556,7 +549,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       TransceiverUtil.parseNumber(newFreq),
       TransceiverUtil.parseNumber(rxFrequencyAdjustment.value)
     );
-    await updateRxFreq(freq);
+    await sendRxFreq(freq);
   });
 
   /**
@@ -568,12 +561,9 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       return;
     }
 
-    // 基準周波数の和を更新する（逆ヘテロダインの計算用、補正値を反映したもの）
-    calcBaseFreqSum();
-
     // 補正値を反映した周波数を無線機に送信する
     const freq = calcAdjustedFreq(TransceiverUtil.parseNumber(rxFrequency.value), TransceiverUtil.parseNumber(newFreq));
-    await updateRxFreq(freq);
+    await sendRxFreq(freq);
   });
 
   /**
@@ -615,7 +605,7 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   });
 
   /**
-   * Rx運用モードが変更された場合
+   * 画面でRx運用モードが変更された場合
    * TODO: SPLITモードの場合のサーバ処理がないので、今はSPLITモードの時も何もしない
    */
   watch(rxOpeMode, async (newRxOpeMode) => {
@@ -713,16 +703,13 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     const nowTxFreq = TransceiverUtil.parseNumber(txFrequency.value);
     const adjustRxFreq = TransceiverUtil.parseNumber(rxFrequencyAdjustment.value);
     const adjustTxFreq = TransceiverUtil.parseNumber(txFrequencyAdjustment.value);
-    // const adjustedRxFreq = calcAdjustedFreq(nowRxFreq, adjustRxFreq);
-    // const adjustedTxFreq = calcAdjustedFreq(nowTxFreq, adjustTxFreq);
     const shiftRx = dopplerRxBaseFreq.value - nowRxFreq;
     const shiftTx = dopplerTxBaseFreq.value - nowTxFreq;
     AppRendererLogger.debug(
       `ドップラーシフト補正後:Rx=${nowRxFreq} Tx=${nowTxFreq}` +
         ` シフト値：Rx=${shiftRx} Tx=${shiftTx}` +
         ` 補正値：Rx=${adjustRxFreq} Tx=${adjustTxFreq}` +
-        ` 基準周波数:${getBaseFreqSum()}=(${dopplerRxBaseFreq.value} + ${adjustRxFreq}` +
-        ` + ${dopplerTxBaseFreq.value} + ${adjustTxFreq})`
+        ` 基準周波数:${getBaseFreqSum()}=${dopplerRxBaseFreq.value} + ${dopplerTxBaseFreq.value}`
     );
   }
 
@@ -798,12 +785,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       }
       // 以降、AutoOn時の基準周波数更新処理
 
-      // 補正値（基準周波数を補正するためのRx、Txの和）
-      const adjustRxFreq = TransceiverUtil.parseNumber(rxFrequencyAdjustment.value);
-      const adjustFreq = adjustRxFreq + adjustTxFreq;
-
       // ドップラーシフトの基準周波数を再算出する
-      const { rxBaseFreq, txBaseFreq } = await calcBaseFreqByShiftedTxFreq(getBaseFreqSum(), adjustFreq, recvTxFreq);
+      const { rxBaseFreq, txBaseFreq } = await calcBaseFreqByShiftedTxFreq(getBaseFreqSum(), adjustTxFreq, recvTxFreq);
       dopplerRxBaseFreq.value = rxBaseFreq;
       dopplerTxBaseFreq.value = txBaseFreq;
 
@@ -841,12 +824,8 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
       }
       // 以降、AutoOn時の基準周波数更新処理
 
-      // 補正値（基準周波数を補正するためのRx、Txの和）
-      const adjustTxFreq = TransceiverUtil.parseNumber(txFrequencyAdjustment.value);
-      const adjustFreq = adjustRxFreq + adjustTxFreq;
-
       // ドップラーシフトの基準周波数を再算出する
-      const { rxBaseFreq, txBaseFreq } = await calcBaseFreqByShiftedRxFreq(getBaseFreqSum(), adjustFreq, recvRxFreq);
+      const { rxBaseFreq, txBaseFreq } = await calcBaseFreqByShiftedRxFreq(getBaseFreqSum(), adjustRxFreq, recvRxFreq);
       dopplerRxBaseFreq.value = rxBaseFreq;
       dopplerTxBaseFreq.value = txBaseFreq;
 
@@ -981,12 +960,12 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   /**
    * ドップラーシフトされたRx周波数を元に、Rx、Tx基準周波数を算出する
    * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
-   * @param shiftedRxFreq ドップラー補正されたRx周波数
+   * @param shiftedAndAdjustedRxFreq ドップラー補正されたRx周波数（補正値適用済みの値）
    */
   async function calcBaseFreqByShiftedRxFreq(
     baseFreqNum: number,
     adjustFreq: number,
-    shiftedRxFreq: number
+    shiftedAndAdjustedRxFreq: number
   ): Promise<{ rxBaseFreq: number; txBaseFreq: number }> {
     const activeSatHubService = ActiveSatServiceHub.getInstance();
     const frequencyTrackService = activeSatHubService.getFrequencyTrackService();
@@ -1001,10 +980,10 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     );
 
     // Rx、Txの基準周波数を更新する
+    const shiftedTxFreq = shiftedAndAdjustedRxFreq - adjustFreq;
     const { rxBaseFreq, txBaseFreq } = frequencyTrackService.calcInvHeteroBaseFreqByRxFreq(
       baseFreqNum,
-      adjustFreq,
-      shiftedRxFreq,
+      shiftedTxFreq,
       rxDopplerFactor
     );
 
@@ -1014,12 +993,12 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   /**
    * ドップラーシフトされたTx周波数を元に、Rx、Tx基準周波数を算出する
    * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
-   * @param shiftedTxFreq ドップラー補正されたTx周波数
+   * @param shiftedAndAdjustedTxFreq ドップラー補正されたTx周波数（補正値適用済みの値）
    */
   async function calcBaseFreqByShiftedTxFreq(
     baseFreqNum: number,
     adjustFreq: number,
-    shiftedTxFreq: number
+    shiftedAndAdjustedTxFreq: number
   ): Promise<{ rxBaseFreq: number; txBaseFreq: number }> {
     const activeSatHubService = ActiveSatServiceHub.getInstance();
 
@@ -1035,9 +1014,9 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     );
 
     // Rx、Txの基準周波数を更新する
+    const shiftedTxFreq = shiftedAndAdjustedTxFreq - adjustFreq;
     const { rxBaseFreq, txBaseFreq } = frequencyTrackService.calcInvHeteroBaseFreqByTxFreq(
       baseFreqNum,
-      adjustFreq,
       shiftedTxFreq,
       txDopplerFactor
     );
@@ -1046,24 +1025,16 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
   }
 
   /**
-   * 現在の衛星の送受信周波数の和を取得する（逆ヘテロダインの計算用、補正値が反映されたもの）
+   * 現在の衛星の送受信周波数の和を取得する（逆ヘテロダインの計算用）
    */
   function getBaseFreqSum(): number {
     return baseFreqSum.value;
   }
 
   /**
-   * 基準周波数の和を更新する（逆ヘテロダインの計算用、補正値を反映したもの）
+   * 基準周波数の和を更新する（逆ヘテロダインの計算用）
    */
   function calcBaseFreqSum(): number {
-    baseFreqSum.value = getBaseFreqSumWithAdjust();
-    return baseFreqSum.value;
-  }
-
-  /**
-   * 現在の衛星の送受信周波数の和を取得する（逆ヘテロダインの計算用。画面の補正値を反映したもの）
-   */
-  function getBaseFreqSumWithAdjust(): number {
     // アクティブ衛星の周波数設定値を取得する
     const activeSatHubService = ActiveSatServiceHub.getInstance();
     const setting = activeSatHubService.getActiveSatTransceiverSetting();
@@ -1076,12 +1047,9 @@ const useTransceiverCtrl = (currentDate: Ref<Date>) => {
     if (downlinkHz === null || uplinkHz === null) {
       return 0;
     }
-    const settingFreq = downlinkHz + uplinkHz;
 
-    // 画面で設定された補正値を反映した周波数を基準周波数として返す
-    const adjustRxFreq = TransceiverUtil.parseNumber(rxFrequencyAdjustment.value);
-    const adjustTxFreq = TransceiverUtil.parseNumber(txFrequencyAdjustment.value);
-    return settingFreq + adjustRxFreq + adjustTxFreq;
+    baseFreqSum.value = downlinkHz + uplinkHz;
+    return baseFreqSum.value;
   }
 
   /**

--- a/src/renderer/service/FrequencyTrackService.ts
+++ b/src/renderer/service/FrequencyTrackService.ts
@@ -53,42 +53,38 @@ export default class FrequencyTrackService {
 
   /**
    * ドップラー補正されたRx周波数とドップラーファクターを元に基準周波数を算出する（逆ヘテロダイン）
-   * @param freqSum 送受信周波数の和（補正値適用済みの値）
-   * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
+   * @param freqSum 送受信周波数の和
    * @param shiftedRxFreq ドップラー補正されたRx周波数
    * @param rxDopplerFactor 受信ドップラーファクター
    */
   public calcInvHeteroBaseFreqByRxFreq(
     freqSum: number,
-    adjustFreq: number,
     shiftedRxFreq: number,
     rxDopplerFactor: number
   ): { rxBaseFreq: number; txBaseFreq: number } {
     // Rx周波数をドップラーファクターで割り戻して、Rx基準周波数を算出する
     const rxBaseFreq = Math.round(shiftedRxFreq / rxDopplerFactor);
     // Tx基準周波数は、送受信周波数の和からRx基準周波数を引いて算出する
-    const txBaseFreq = Math.round(freqSum - adjustFreq) - rxBaseFreq;
+    const txBaseFreq = Math.round(freqSum) - rxBaseFreq;
 
     return { rxBaseFreq, txBaseFreq };
   }
 
   /**
    * ドップラー補正されたTx周波数とドップラーファクターを元に基準周波数を算出する（逆ヘテロダイン）
-   * @param freqSum 送受信周波数の和（補正値適用済みの値）
-   * @param adjustFreq 補正値（Rx補正値、Tx補正値の和）
-   * @param shiftedTxFreq ドップラー補正されたTx周波数
+   * @param freqSum 送受信周波数の和
+   * @param shiftedTxFreq ドップラー補正されたTx周波数（補正値除去済みの値）
    * @param txDopplerFactor Txドップラーファクター
    */
   public calcInvHeteroBaseFreqByTxFreq(
     freqSum: number,
-    adjustFreq: number,
     shiftedTxFreq: number,
     txDopplerFactor: number
   ): { rxBaseFreq: number; txBaseFreq: number } {
     // Tx周波数をドップラーファクターで割り戻して、Tx基準周波数を算出する
     const txBaseFreq = Math.round(shiftedTxFreq / txDopplerFactor);
     // Rx基準周波数は、送受信周波数の和からTx基準周波数を引いて算出する
-    const rxBaseFreq = Math.round(freqSum - adjustFreq) - txBaseFreq;
+    const rxBaseFreq = Math.round(freqSum) - txBaseFreq;
 
     return { rxBaseFreq, txBaseFreq };
   }

--- a/src/renderer/service/FrequencyTrackService.ts
+++ b/src/renderer/service/FrequencyTrackService.ts
@@ -54,7 +54,7 @@ export default class FrequencyTrackService {
   /**
    * ドップラー補正されたRx周波数とドップラーファクターを元に基準周波数を算出する（逆ヘテロダイン）
    * @param freqSum 送受信周波数の和
-   * @param shiftedRxFreq ドップラー補正されたRx周波数
+   * @param shiftedRxFreq ドップラー補正されたRx周波数（補正値除去済みの値）
    * @param rxDopplerFactor 受信ドップラーファクター
    */
   public calcInvHeteroBaseFreqByRxFreq(


### PR DESCRIPTION
- Rx/Tx周波数の「補正値」は基準周波数の和には適用しない。
- 無線機に送信するRx/Tx周波数に「補正値」を適用する。（なぜか対応済みだった）
- 無線機から受信した補正値適用済みの周波数は、補正値を除去して画面に反映する。（なぜか対応済みだった）
