### PR TITLE
設定インポート、エクスポートを一時的に無効化

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -92,11 +92,13 @@ export function makeElectronMenu(): Electron.Menu {
         // 設定インポート
         {
           label: I18nUtil4Main.getMsg(I18nMsgs.GCOM_MENU_IMPORT_CONFIG),
+          enabled: false, // MEMO: 一時的に無効化
           click: () => new AppConfigImportSerivce().importAppConfig(),
         },
         // 設定エクスポート
         {
           label: I18nUtil4Main.getMsg(I18nMsgs.GCOM_MENU_EXPORT_CONFIG),
+          enabled: false, // MEMO: 一時的に無効化
           click: () => new AppConfigExportSerivce().exportAppConfig(),
         },
 
@@ -129,11 +131,13 @@ export function makeElectronMenu(): Electron.Menu {
         // 設定インポート
         {
           label: I18nUtil4Main.getMsg(I18nMsgs.GCOM_MENU_IMPORT_CONFIG),
+          enabled: false, // MEMO: 一時的に無効化
           click: () => new AppConfigImportSerivce().importAppConfig(),
         },
         // 設定エクスポート
         {
           label: I18nUtil4Main.getMsg(I18nMsgs.GCOM_MENU_EXPORT_CONFIG),
+          enabled: false, // MEMO: 一時的に無効化
           click: () => new AppConfigExportSerivce().exportAppConfig(),
         },
 


### PR DESCRIPTION
現状、設定のインポート、エクスポートは動作が保証されないため、一時的に無効化する。