### PR TITLE
新規衛星追加

### DIFF
--- a/satellite_data/frequency.json
+++ b/satellite_data/frequency.json
@@ -1,6 +1,6 @@
 {
   "frequency": {
-    "lastUpdateTime": 1777704357246,
+    "lastUpdateTime": 1781390008265,
     "satellites": [
       {
         "noradId": "43017",
@@ -780,6 +780,510 @@
         "downlink2": {
           "downlinkHz": 436830000,
           "downlinkMode": "FM"
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": null,
+          "beaconMode": ""
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63217",
+        "satelliteName": "TEVEL2-1",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63219",
+        "satelliteName": "TEVEL2-2",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63218",
+        "satelliteName": "TEVEL2-3",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63213",
+        "satelliteName": "TEVEL2-4",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63214",
+        "satelliteName": "TEVEL2-5",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63215",
+        "satelliteName": "TEVEL2-6",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63238",
+        "satelliteName": "TEVEL2-7",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63239",
+        "satelliteName": "TEVEL2-8",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "63237",
+        "satelliteName": "TEVEL2-9",
+        "uplink1": {
+          "uplinkHz": 145970000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436400000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": 436400000,
+          "beaconMode": "FM-D"
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "67282",
+        "satelliteName": "RS83S",
+        "uplink1": {
+          "uplinkHz": 435500000,
+          "uplinkMode": "FM"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 145910000,
+          "downlinkMode": "FM"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": null,
+          "beaconMode": ""
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "68446",
+        "satelliteName": "HADES-SA",
+        "uplink1": {
+          "uplinkHz": 145875000,
+          "uplinkMode": "USB-D"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 436875000,
+          "downlinkMode": "USB-D"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": null,
+          "beaconMode": ""
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "68422",
+        "satelliteName": "Lilium-4",
+        "uplink1": {
+          "uplinkHz": 145825000,
+          "uplinkMode": "FM-D"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 145825000,
+          "downlinkMode": "FM-D"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": null,
+          "beaconMode": ""
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "68456",
+        "satelliteName": "PARUS-6U1",
+        "uplink1": {
+          "uplinkHz": 145825000,
+          "uplinkMode": "FM-D"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 145825000,
+          "downlinkMode": "FM-D"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "downlink3": {
+          "downlinkHz": null,
+          "downlinkMode": ""
+        },
+        "beacon": {
+          "beaconHz": null,
+          "beaconMode": ""
+        },
+        "enableSatelliteMode": false,
+        "satelliteMode": "NORMAL",
+        "toneHz": null,
+        "outline": ""
+      },
+      {
+        "noradId": "68635",
+        "satelliteName": "CANVAS",
+        "uplink1": {
+          "uplinkHz": 437250000,
+          "uplinkMode": "FM-D"
+        },
+        "uplink2": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "uplink3": {
+          "uplinkHz": null,
+          "uplinkMode": ""
+        },
+        "downlink1": {
+          "downlinkHz": 437250000,
+          "downlinkMode": "FM-D"
+        },
+        "downlink2": {
+          "downlinkHz": null,
+          "downlinkMode": ""
         },
         "downlink3": {
           "downlinkHz": null,

--- a/satellite_data/frequency.json
+++ b/satellite_data/frequency.json
@@ -1159,7 +1159,7 @@
         "satelliteName": "HADES-SA",
         "uplink1": {
           "uplinkHz": 145875000,
-          "uplinkMode": "USB-D"
+          "uplinkMode": "FM"
         },
         "uplink2": {
           "uplinkHz": null,
@@ -1171,7 +1171,7 @@
         },
         "downlink1": {
           "downlinkHz": 436875000,
-          "downlinkMode": "USB-D"
+          "downlinkMode": "FM"
         },
         "downlink2": {
           "downlinkHz": null,


### PR DESCRIPTION
| NORADID | 衛星名 | uplink1周波数 | uplink1モード | downlink1周波数 | downlink1モード | beacon周波数 | beaconモード |
|---:|---|---:|---|---:|---|---:|---|
| 63217 | TEVEL2-1 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63219 | TEVEL2-2 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63218 | TEVEL2-3 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63213 | TEVEL2-4 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63214 | TEVEL2-5 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63215 | TEVEL2-6 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63238 | TEVEL2-7 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63239 | TEVEL2-8 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 63237 | TEVEL2-9 | 145.970 MHz | FM | 436.400 MHz | FM | 436.400 MHz | FM-D |
| 67282 | RS83S | 435.500 MHz | FM | 145.910 MHz | FM | - | - |
| 68446 | HADES-SA | 145.875 MHz | FM | 436.875 MHz | FM | - | - |
| 68422 | Lilium-4 | 145.825 MHz | FM-D | 145.825 MHz | FM-D | - | - |
| 68456 | PARUS-6U1 | 145.825 MHz | FM-D | 145.825 MHz | FM-D | - | - |
| 68635 | CANVAS | 437.250 MHz | FM-D | 437.250 MHz | FM-D | - | - |