### PR TITLE
無線機エリアの縦の余白を調整

### DIFF
--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
@@ -6,7 +6,7 @@
 }
 
 .fieldset_area {
-  margin-top: 5px;
+  margin-top: 2px;
   border-radius: 4px;
 }
 
@@ -71,8 +71,8 @@
 
 // Modeボタン
 .mode_btn {
-  width: 100px;
-  margin: 5px;
+  width: 98px;
+  margin: 2px 5px;
   height: 30px;
 }
 .mode_btn_on {
@@ -90,7 +90,7 @@
   display: inline-block;
   vertical-align: middle;
   margin-left: 7px;
-  margin-bottom: 3px;
+  margin-bottom: 2px;
 }
 .mode_select_box {
   margin-top: 2px;
@@ -99,13 +99,13 @@
   margin-left: 8px;
   font-size: 1.4rem;
   text-align: right;
-  width: 180px;
-  height: 38px;
+  width: 178px;
+  height: 30px;
 }
 // Satelliteボタン
 .sat_btn {
-  width: 210px;
-  margin: 5px;
+  width: 206px;
+  margin: 2px 5px;
   height: 30px;
 }
 .sat_btn_on {
@@ -122,7 +122,7 @@
 // Beaconボタン
 .beacon_btn {
   width: 100px;
-  margin: 5px;
+  margin: 2px 5px;
   height: 30px;
 }
 .beacon_btn_right {
@@ -148,14 +148,14 @@
   user-select: none;
   margin-right: 7px;
   margin-left: 7px;
-  margin-bottom: 3px;
+  margin-bottom: 2px;
 }
 
 .freq_area {
   user-select: none;
   display: inline-block;
   margin-left: 7px;
-  margin-bottom: 3px;
+  margin-bottom: 2px;
 }
 
 .freq_box {
@@ -173,7 +173,7 @@
   user-select: none;
   display: flex;
   margin-right: 35px;
-  margin-bottom: 3px;
+  margin-bottom: 2px;
   justify-content: flex-end;
 }
 .freq_box_sub {
@@ -228,4 +228,10 @@
   @extend .item_label;
   background-color: $black100;
   color: $white;
+}
+
+.mode_label {
+  display: inline-block;
+  width: 18px;
+  text-align: center;
 }

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.scss
@@ -6,7 +6,7 @@
 }
 
 .fieldset_area {
-  margin-top: 10px;
+  margin-top: 5px;
   border-radius: 4px;
 }
 
@@ -66,7 +66,7 @@
   width: 100%;
   height: 30px !important;
   font-size: 1rem !important;
-  margin-top: 5px;
+  margin-top: 2px;
 }
 
 // Modeボタン
@@ -90,10 +90,10 @@
   display: inline-block;
   vertical-align: middle;
   margin-left: 7px;
-  margin-bottom: 7px;
+  margin-bottom: 3px;
 }
 .mode_select_box {
-  margin-top: 5px;
+  margin-top: 2px;
   display: inline-block;
   vertical-align: middle;
   margin-left: 8px;
@@ -148,18 +148,18 @@
   user-select: none;
   margin-right: 7px;
   margin-left: 7px;
-  margin-bottom: 7px;
+  margin-bottom: 3px;
 }
 
 .freq_area {
   user-select: none;
   display: inline-block;
   margin-left: 7px;
-  margin-bottom: 7px;
+  margin-bottom: 3px;
 }
 
 .freq_box {
-  margin-top: 5px;
+  margin-top: 2px;
   display: inline-block;
   margin-left: 8px;
   font-size: 1.4rem;
@@ -173,11 +173,11 @@
   user-select: none;
   display: flex;
   margin-right: 35px;
-  margin-bottom: 7px;
+  margin-bottom: 3px;
   justify-content: flex-end;
 }
 .freq_box_sub {
-  margin-top: 5px;
+  margin-top: 2px;
   margin-left: auto;
   font-size: 1.2rem;
   text-align: right;

--- a/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
+++ b/src/renderer/components/organisms/TransceiverCtrl/TransceiverCtrl.vue
@@ -61,11 +61,11 @@
     <fieldset class="fieldset_area">
       <legend class="item_group_legend">Mode</legend>
       <div class="mode_area">
-        <div>Rx<OpeModeSelect v-model="rxOpeMode" class="mode_select_box" /></div>
+        <div><span class="mode_label">Rx</span><OpeModeSelect v-model="rxOpeMode" class="mode_select_box" /></div>
       </div>
       <br class="br_no_select" />
       <div class="mode_area">
-        <div>Tx<OpeModeSelect v-model="txOpeMode" class="mode_select_box" /></div>
+        <div><span class="mode_label">Tx</span><OpeModeSelect v-model="txOpeMode" class="mode_select_box" /></div>
       </div>
       <br class="br_no_select" />
 

--- a/src/renderer/components/pages/Home/Home.scss
+++ b/src/renderer/components/pages/Home/Home.scss
@@ -27,7 +27,7 @@ $main_right_width: 260px;
 // 右側
 .main_right {
   position: absolute;
-  margin: 10px;
+  margin: 2px 10px;
   top: 0px;
   left: calc(100vw - $main_right_width);
   width: calc($main_right_width - 40px);


### PR DESCRIPTION
# 前提
- 縦スクロールが発生して周波数のホイールでスクロールを誘発してしまうことがあった

# 実装概要
- スクロールしないように縦を詰める
- ついでにmodeの横幅を整列

左：修正前／右：修正後
<img width="400" height="800" alt="image" src="https://github.com/user-attachments/assets/4ac66b43-6ee6-4d17-99fb-34bf5540ae9d" />


# 注意点
- なし

# 関連
- なし
