### PR TITLE
lilium-4およびその他のnoradidや衛星名をamsatのtleをベースに修正

### DIFF
--- a/satellite_data/frequency.json
+++ b/satellite_data/frequency.json
@@ -76,7 +76,7 @@
       },
       {
         "noradId": "43678",
-        "satelliteName": "DIWATA-2B",
+        "satelliteName": "PO-101 (DIWATA-2)",
         "uplink1": {
           "uplinkHz": 437500000,
           "uplinkMode": "FM"
@@ -579,7 +579,7 @@
         "outline": ""
       },
       {
-        "noradId": "98323",
+        "noradId": "68798",
         "satelliteName": "MAGNARO-II Piscis",
         "uplink1": {
           "uplinkHz": null,
@@ -651,7 +651,7 @@
         "outline": ""
       },
       {
-        "noradId": "98327",
+        "noradId": "63797",
         "satelliteName": "WASEDA-SAT-ZERO-II",
         "uplink1": {
           "uplinkHz": null,
@@ -1191,7 +1191,7 @@
         "outline": ""
       },
       {
-        "noradId": "68422",
+        "noradId": "71922",
         "satelliteName": "Lilium-4",
         "uplink1": {
           "uplinkHz": 145825000,


### PR DESCRIPTION
# 前提
- AMSATのTLEをみるとLilium-4のNORADIDが間違っている

# 実装概要
- Liliumu-4およびその他の衛星のNORADIDおよび衛星名をamsatのtleをベースに修正

# 注意点
- なし

# 関連
- なし
